### PR TITLE
Improve sync transactions code

### DIFF
--- a/src/main/java/com/flippingcopilot/controller/GameUiChangesHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/GameUiChangesHandler.java
@@ -74,7 +74,9 @@ public class GameUiChangesHandler {
         {
             OfferEditor flippingWidget = new OfferEditor(offerManager, client.getWidget(ComponentID.CHATBOX_CONTAINER), offerHandler, client);
             Suggestion suggestion = suggestionManager.getSuggestion();
-            flippingWidget.showSuggestion(suggestion);
+            if (suggestion != null) {
+                flippingWidget.showSuggestion(suggestion);
+            }
         });
     }
 

--- a/src/main/java/com/flippingcopilot/controller/SuggestionController.java
+++ b/src/main/java/com/flippingcopilot/controller/SuggestionController.java
@@ -60,6 +60,9 @@ public class SuggestionController {
     }
 
     void onGameTick() {
+        if(suggestionManager.isSuggestionRequestInProgress()) {
+            return;
+        }
         // There is a race condition when the collect button is hit at the same time as offers fill.
         // In such a case we can end up with the uncollectedManager falsely thinking there is items to collect.
         // We identify if this has happened here by checking if the collect button is actually visible.

--- a/src/main/java/com/flippingcopilot/model/FlipManager.java
+++ b/src/main/java/com/flippingcopilot/model/FlipManager.java
@@ -60,8 +60,8 @@ public class FlipManager {
     }
 
     public synchronized long estimateTransactionProfit(String displayName, Transaction t) {
-        int accountId = displayNameToAccountId.get(displayName);
-        if (lastOpenFLipByItemId.containsKey(accountId)) {
+        Integer accountId = displayNameToAccountId.get(displayName);
+        if (accountId != null && lastOpenFLipByItemId.containsKey(accountId)) {
             FlipV2 flip = lastOpenFLipByItemId.get(accountId).get(t.getItemId());
             if(flip != null) {
                 return flip.calculateProfit(t);

--- a/src/main/java/com/flippingcopilot/model/GrandExchangeUncollectedManager.java
+++ b/src/main/java/com/flippingcopilot/model/GrandExchangeUncollectedManager.java
@@ -20,8 +20,7 @@ public class GrandExchangeUncollectedManager {
     // dependencies
     private final Client client;
 
-    // state
-    @Getter
+    // stated
     private int lastUncollectedAddedTick = -1;
     private int lastClearedTick = -1;
     private final Map<Integer, Long> lastClearedUncollected = new HashMap<>();
@@ -123,7 +122,11 @@ public class GrandExchangeUncollectedManager {
         return lastClearedSlots;
     }
 
-    public void reset() {
+    public synchronized int getLastUncollectedAddedTick() {
+        return lastUncollectedAddedTick;
+    }
+
+    public synchronized void reset() {
         lastClearedUncollected.clear();
         lastClearedTick = -1;
         lastUncollectedAddedTick = -1;


### PR DESCRIPTION
We sync transactions to our server. The server logs suggest cases where the list of transactions waiting to sync grows very large with duplicates, eventually resulting in large requests to our server and congesting the user's bandwidth. Although I can't re-produce this. A possible cause is here:

```java
            for (Transaction transaction: transactionsToProcess) {
                long profit = transactionManager.addTransaction(transaction, displayName);
                if (grandExchange.isHomeScreenOpen() && profit != 0) {
                    new GpDropOverlay(overlayManager, client, profit, transaction.getBoxId());
                }
            }
            transactionsToProcess.clear();
``` 

If an exception happens prior to `transactionsToProcess.clear();` being called the same transaction(s) would repeatedly be added on every tick.

There are two descrepencies I can identify inside the `TransactionManger` as possible causes of this.

One is that the lines `new ArrayList<>(getUnAckedTransactions(displayName));` and `unAckedTransactions.add(transaction);` could execute at the same time causing a `ConcurrentModificationException` (even though an underlying `Collections.synchronizedList` is used, this isn't sufficent to prevent this). The second is that if `calculateProfit` threw an exception via a divide by zero or something (although I couldn't see from the code how this could happen, this would make sense as it would be determisitic and keep happening).

This change should fix these possible causes by:

- Improve the TransactionManager thread safety so that a `ConcurrentModificationException` isn't possible.
- Use a queue for the transactions to process rather than a list so even if an exception happens then the transaction is already popped and won't be re-try'd.
 
