### PR TITLE
Further improvements

### DIFF
--- a/src/main/java/com/flippingcopilot/controller/CopilotLoginController.java
+++ b/src/main/java/com/flippingcopilot/controller/CopilotLoginController.java
@@ -29,6 +29,7 @@ public class CopilotLoginController {
     private final SuggestionManager suggestionManager;
     private final OsrsLoginManager osrsLoginManager;
     private final SessionManager sessionManager;
+    private final TransactionManger transactionManger;
 
     // state
     private String email;
@@ -39,10 +40,11 @@ public class CopilotLoginController {
             if (loginResponseManager.isLoggedIn()) {
                 flipManager.loadFlipsAsync();
                 mainPanel.refresh();
-                String displayName = osrsLoginManager.getLastDisplayName();
+                String displayName = osrsLoginManager.getPlayerDisplayName();
                 if(displayName != null) {
                     flipManager.setIntervalDisplayName(displayName);
                     flipManager.setIntervalStartTime(sessionManager.getCachedSessionData().startTime);
+                    transactionManger.scheduleSyncIn(0, displayName);
                 }
             } else {
                 LoginResponse loginResponse = loginResponseManager.getLoginResponse();

--- a/src/main/java/com/flippingcopilot/controller/FlippingCopilotPlugin.java
+++ b/src/main/java/com/flippingcopilot/controller/FlippingCopilotPlugin.java
@@ -127,8 +127,9 @@ public class FlippingCopilotPlugin extends Plugin {
 					AccountStatus accStatus = accountStatusManager.getAccountStatus();
 					boolean isFlipping = accStatus != null && accStatus.currentlyFlipping();
 					long cashStack = accStatus == null ? 0 : accStatus.currentCashStack();
-					sessionManager.updateSessionStats(isFlipping, cashStack);
-					mainPanel.copilotPanel.statsPanel.refresh(false, loginResponseManager.isLoggedIn() && osrsLoginManager.isValidLoginState());
+					if(sessionManager.updateSessionStats(isFlipping, cashStack)) {
+						mainPanel.copilotPanel.statsPanel.refresh(false, loginResponseManager.isLoggedIn() && osrsLoginManager.isValidLoginState());
+					}
 				}
 			})
 		, 2000, 1000, TimeUnit.MILLISECONDS);
@@ -232,7 +233,9 @@ public class FlippingCopilotPlugin extends Plugin {
 					flipManager.setIntervalStartTime(sessionManager.getCachedSessionData().startTime);
 					statsPanel.refresh(true, loginResponseManager.isLoggedIn()  && osrsLoginManager.isValidLoginState());
 					mainPanel.refresh();
-					transactionManger.scheduleSyncIn(0, name);
+					if(loginResponseManager.isLoggedIn()) {
+						transactionManger.scheduleSyncIn(0, name);
+					}
 					return true;
 				});
 		}

--- a/src/main/java/com/flippingcopilot/controller/GameUiChangesHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/GameUiChangesHandler.java
@@ -1,6 +1,7 @@
 package com.flippingcopilot.controller;
 
 import com.flippingcopilot.model.OfferManager;
+import com.flippingcopilot.model.OfferStatus;
 import com.flippingcopilot.model.Suggestion;
 import com.flippingcopilot.model.SuggestionManager;
 import com.flippingcopilot.ui.OfferEditor;
@@ -87,6 +88,9 @@ public class GameUiChangesHandler {
     }
 
     public void onWidgetLoaded(WidgetLoaded event) {
+        if (event.getGroupId() == InterfaceID.GRAND_EXCHANGE) {
+            suggestionManager.setSuggestionNeeded(true);
+        }
         if (event.getGroupId() == 383
                 || event.getGroupId() == InterfaceID.GRAND_EXCHANGE
                 || event.getGroupId() == 213
@@ -98,6 +102,7 @@ public class GameUiChangesHandler {
     public void onWidgetClosed(WidgetClosed event) {
         if (event.getGroupId() == InterfaceID.GRAND_EXCHANGE) {
             clientThread.invokeLater(highlightController::removeAll);
+            suggestionManager.setSuggestionNeeded(true);
         }
     }
 
@@ -121,6 +126,24 @@ public class GameUiChangesHandler {
             offerManager.setOfferJustPlaced(true);
             suggestionManager.setLastOfferSubmittedTick(client.getTickCount());
             suggestionManager.setSuggestionNeeded(true);
+            Suggestion suggestion = suggestionManager.getSuggestion();
+            if(suggestion != null) {
+                suggestionManager.setSuggestionItemIdOnOfferSubmitted(suggestion.getItemId());
+                suggestionManager.setSuggestionOfferStatusOnOfferSubmitted(suggestionOfferStatus(suggestion));
+            } else {
+                suggestionManager.setSuggestionItemIdOnOfferSubmitted(-1);
+                suggestionManager.setSuggestionOfferStatusOnOfferSubmitted(null);
+            }
+        }
+    }
+
+    private OfferStatus suggestionOfferStatus(Suggestion suggestion) {
+        if ("sell".equals(suggestion.getType())) {
+            return OfferStatus.SELL;
+        } else if ("buy".equals(suggestion.getType())) {
+            return OfferStatus.BUY;
+        } else {
+            return null;
         }
     }
 }

--- a/src/main/java/com/flippingcopilot/controller/GrandExchange.java
+++ b/src/main/java/com/flippingcopilot/controller/GrandExchange.java
@@ -3,6 +3,7 @@ package com.flippingcopilot.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
 
 import javax.inject.Inject;
@@ -28,11 +29,11 @@ public class GrandExchange {
     }
 
     boolean isOpen() {
-        return client.getWidget(465, 7) != null;
+        return client.getWidget(InterfaceID.GRAND_EXCHANGE, 7) != null;
     }
 
     boolean isCollectButtonVisible() {
-        Widget w = client.getWidget(465, 6);
+        Widget w = client.getWidget(InterfaceID.GRAND_EXCHANGE, 6);
         if (w == null) {
             return false;
         }

--- a/src/main/java/com/flippingcopilot/controller/GrandExchangeOfferEventHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/GrandExchangeOfferEventHandler.java
@@ -66,6 +66,7 @@ public class GrandExchangeOfferEventHandler {
         }
 
         o.setCopilotPriceUsed(wasCopilotPriceUsed(o, prev));
+        o.setWasCopilotSuggestion(wasCopilotSuggestion(o, prev));
 
         boolean consistent = isConsistent(prev, o);
         if(!consistent) {
@@ -76,7 +77,7 @@ public class GrandExchangeOfferEventHandler {
             suggestionManager.setSuggestionNeeded(true);
         }
 
-        Transaction t = inferTransaction( slot, o, prev, consistent);
+        Transaction t = inferTransaction(slot, o, prev, consistent);
         if(t != null) {
             transactionsToProcess.add(t);
             processTransactions();
@@ -96,6 +97,14 @@ public class GrandExchangeOfferEventHandler {
             return o.getItemId() == offerManager.getLastViewedSlotItemId() && o.getPrice() == offerManager.getLastViewedSlotItemPrice() && Instant.now().minusSeconds(30).getEpochSecond() < offerManager.getLastViewedSlotPriceTime();
         } else {
             return prev.isCopilotPriceUsed();
+        }
+    }
+
+    private boolean wasCopilotSuggestion(SavedOffer o, SavedOffer prev) {
+        if(isNewOffer(prev, o)){
+            return o.getItemId() == suggestionManager.getSuggestionItemIdOnOfferSubmitted() && o.getOfferStatus().equals(suggestionManager.getSuggestionOfferStatusOnOfferSubmitted());
+        } else {
+            return prev.isWasCopilotSuggestion();
         }
     }
 
@@ -159,7 +168,8 @@ public class GrandExchangeOfferEventHandler {
             t.setBoxId(slot);
             t.setAmountSpent(amountSpentDiff);
             t.setTimestamp(Instant.now());
-            t.setCopilotPriceUsed(true);
+            t.setCopilotPriceUsed(offer.isCopilotPriceUsed());
+            t.setWasCopilotSuggestion(offer.isWasCopilotSuggestion());
             t.setOfferTotalQuantity(offer.getTotalQuantity());
             t.setLogin(login);
             t.setConsistent(consistent);

--- a/src/main/java/com/flippingcopilot/controller/OfferHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/OfferHandler.java
@@ -1,9 +1,6 @@
 package com.flippingcopilot.controller;
 
-import com.flippingcopilot.model.OfferManager;
-import com.flippingcopilot.model.OsrsLoginManager;
-import com.flippingcopilot.model.Suggestion;
-import com.flippingcopilot.model.SuggestionManager;
+import com.flippingcopilot.model.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +32,7 @@ public class OfferHandler {
     private final OsrsLoginManager osrsLoginManager;
     private final OfferManager offerManager;
     private final HighlightController highlightController;
+    private final LoginResponseManager loginResponseManager;
 
     // state
     private String viewedSlotPriceErrorText = null;
@@ -52,6 +50,11 @@ public class OfferHandler {
                 offerManager.setLastViewedSlotItemId(suggestion.getItemId());
                 offerManager.setLastViewedSlotItemPrice(suggestion.getPrice());
                 offerManager.setLastViewedSlotItemPrice((int) Instant.now().getEpochSecond());
+                return;
+            }
+
+            if (!loginResponseManager.isLoggedIn()) {
+                viewedSlotPriceErrorText = "Login to copilot to see item price.";
                 return;
             }
 

--- a/src/main/java/com/flippingcopilot/controller/Persistance.java
+++ b/src/main/java/com/flippingcopilot/controller/Persistance.java
@@ -23,8 +23,7 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 public class Persistance {
@@ -105,8 +104,10 @@ public class Persistance {
         List<Transaction> transactions = new ArrayList<>();
         File file = new File(PARENT_DIRECTORY, String.format(UN_ACKED_TRANSACTIONS_FILE_TEMPLATE, hashDisplayName(displayName)));
         if (!file.exists()) {
+            log.info("no existing un acked transactions file for {}", displayName);
             return new ArrayList<>();
         }
+        Set<UUID> added = new HashSet<>();
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -115,7 +116,12 @@ public class Persistance {
                 }
                 try {
                     Transaction transaction = gson.fromJson(line, Transaction.class);
-                    transactions.add(transaction);
+                    // there was previously a bug where the same transaction was being added many times to the list
+                    // just clean things here to be safe
+                    if (!added.contains(transaction.getId())) {
+                        transactions.add(transaction);
+                        added.add(transaction.getId());
+                    }
                 } catch (JsonSyntaxException e) {
                     log.warn("error deserializing transaction line '{}' file {}", line, file, e);
                 }
@@ -127,18 +133,8 @@ public class Persistance {
             log.warn("error loading un acked transaction file {}", file, e);
             return new ArrayList<>();
         }
+        log.info("loaded {} stored transactions for {}", transactions.size(), displayName);
         return transactions;
-    }
-
-    public static void storeTransaction(Transaction t, String displayName) {
-        File allTransacitonsFile = new File(PARENT_DIRECTORY, String.format(ALL_TRANSACTIONS_FILE_TEMPLATE, hashDisplayName(displayName)));
-        try (BufferedWriter w = new BufferedWriter(new FileWriter(allTransacitonsFile, true))) {
-            String json = gson.toJson(t);
-            w.write(json);
-            w.newLine();
-        } catch (IOException e) {
-            log.warn("error storing un acked transactions to file {}", allTransacitonsFile, e);
-        }
     }
 
     public static void storeUnAckedTransactions(List<Transaction> transactions, String displayName) {

--- a/src/main/java/com/flippingcopilot/controller/SuggestionController.java
+++ b/src/main/java/com/flippingcopilot/controller/SuggestionController.java
@@ -122,6 +122,7 @@ public class SuggestionController {
             showNotifications(oldSuggestion, newSuggestion, accountStatus);
         };
         Consumer<HttpResponseException> onFailure = (e) -> {
+            suggestionManager.setSuggestion(null);
             suggestionManager.setSuggestionError(e);
             suggestionManager.setSuggestionRequestInProgress(false);
             if (e.getResponseCode() == 401) {

--- a/src/main/java/com/flippingcopilot/model/AccountStatus.java
+++ b/src/main/java/com/flippingcopilot/model/AccountStatus.java
@@ -84,7 +84,7 @@ public class AccountStatus {
         if(!requestedSuggestionTypes.isEmpty()) {
            JsonArray rstArray = new JsonArray();
            requestedSuggestionTypes.forEach(rstArray::add);
-           statusJson.add("requestedSuggestionTypes", rstArray);
+           statusJson.add("requested_suggestion_types", rstArray);
         }
         return statusJson;
     }

--- a/src/main/java/com/flippingcopilot/model/AccountStatusManager.java
+++ b/src/main/java/com/flippingcopilot/model/AccountStatusManager.java
@@ -74,10 +74,6 @@ public class AccountStatusManager {
             }
         }
 
-        for(RSItem i : inventory) {
-            log.debug("tick {} inventory item {}, qty {}", client.getTickCount(), i.id, i.amount);
-        }
-
         return status;
     }
 

--- a/src/main/java/com/flippingcopilot/model/FlipManager.java
+++ b/src/main/java/com/flippingcopilot/model/FlipManager.java
@@ -94,6 +94,9 @@ public class FlipManager {
         if (Objects.equals(displayName, intervalDisplayName)) {
             return;
         }
+        if (!displayNameToAccountId.containsKey(displayName)) {
+            displayNameToAccountId.put(displayName, -1);
+        }
         intervalDisplayName = displayName;
         recalculateIntervalStats();
     }

--- a/src/main/java/com/flippingcopilot/model/OfferManager.java
+++ b/src/main/java/com/flippingcopilot/model/OfferManager.java
@@ -29,7 +29,6 @@ public class OfferManager {
     // dependencies
     private final Gson gson;
     private final ScheduledExecutorService executorService;
-    private final Client client;
 
     // state
     @Getter

--- a/src/main/java/com/flippingcopilot/model/SavedOffer.java
+++ b/src/main/java/com/flippingcopilot/model/SavedOffer.java
@@ -16,6 +16,7 @@ public class SavedOffer
 	private int spent;
 	private GrandExchangeOfferState state;
 	private boolean copilotPriceUsed;
+	private boolean wasCopilotSuggestion;
 
 
 	public static SavedOffer fromGrandExchangeOffer(GrandExchangeOffer offer) {
@@ -62,7 +63,7 @@ public class SavedOffer
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		SavedOffer that = (SavedOffer) o;
-		return itemId == that.itemId && quantitySold == that.quantitySold && totalQuantity == that.totalQuantity && price == that.price && spent == that.spent && copilotPriceUsed == that.copilotPriceUsed && state == that.state;
+		return itemId == that.itemId && quantitySold == that.quantitySold && totalQuantity == that.totalQuantity && price == that.price && spent == that.spent && copilotPriceUsed == that.copilotPriceUsed && state == that.state && wasCopilotSuggestion == that.wasCopilotSuggestion;
 	}
 
 	@Override

--- a/src/main/java/com/flippingcopilot/model/SessionManager.java
+++ b/src/main/java/com/flippingcopilot/model/SessionManager.java
@@ -47,12 +47,14 @@ public class SessionManager {
         saveAsync(displayName);
     }
 
-    public synchronized void updateSessionStats(boolean currentlyFlipping, long cashStack) {
+    public synchronized boolean updateSessionStats(boolean currentlyFlipping, long cashStack) {
         String displayName = osrsLoginManager.getPlayerDisplayName();
         if (!currentlyFlipping || displayName == null) {
             lastSessionUpdateTime = null;
+            return false;
         } else if (lastSessionUpdateTime == null) {
             lastSessionUpdateTime = Instant.now();
+            return false;
         } else {
             SessionData sd = getSessionData(displayName);
             Instant now = Instant.now();
@@ -62,6 +64,7 @@ public class SessionManager {
             lastSessionUpdateTime = now;
             sd.averageCash = newAverageCashStack;
             saveAsync(displayName);
+            return true;
         }
     }
 

--- a/src/main/java/com/flippingcopilot/model/SuggestionManager.java
+++ b/src/main/java/com/flippingcopilot/model/SuggestionManager.java
@@ -11,13 +11,21 @@ import java.time.Instant;
 @Setter
 public class SuggestionManager {
 
-    private boolean suggestionNeeded;
-    private boolean suggestionRequestInProgress;
+    private volatile boolean suggestionNeeded;
+    private volatile boolean suggestionRequestInProgress;
     private Instant lastFailureAt;
     private HttpResponseException suggestionError;
     private Suggestion suggestion;
     private Instant suggestionReceivedAt;
     private int lastOfferSubmittedTick = -1;
+
+    // these two variables get set based on the current suggestion when the confirm offer button is clicked.
+    // this allows us to track on the subsequent offer events whether the offer originates from a copilot suggestion
+    // this flag can then eventually be propagated onto each transaction and can be used by the server to
+    // determine which items in the inventory were bought based upon copilot suggestions and which are not
+    private int suggestionItemIdOnOfferSubmitted = -1;
+    private OfferStatus suggestionOfferStatusOnOfferSubmitted = null;
+
 
     public void setSuggestion(Suggestion suggestion) {
         this.suggestion = suggestion;
@@ -36,6 +44,8 @@ public class SuggestionManager {
         lastFailureAt = null;
         lastOfferSubmittedTick = -1;
         suggestionError = null;
+        suggestionItemIdOnOfferSubmitted = -1;
+        suggestionOfferStatusOnOfferSubmitted = null;
     }
 
     public boolean suggestionOutOfDate() {

--- a/src/main/java/com/flippingcopilot/model/Transaction.java
+++ b/src/main/java/com/flippingcopilot/model/Transaction.java
@@ -25,6 +25,7 @@ public class Transaction {
     private int amountSpent;
     private Instant timestamp;
     private boolean copilotPriceUsed;
+    private boolean wasCopilotSuggestion;
     private int offerTotalQuantity;
     private boolean login;
     private boolean consistent;
@@ -48,6 +49,7 @@ public class Transaction {
         jsonObject.addProperty("amount_spent", amountSpent);
         jsonObject.addProperty("time", timestamp.getEpochSecond());
         jsonObject.addProperty("copilot_price_used", copilotPriceUsed);
+        jsonObject.addProperty("was_copilot_suggestion", wasCopilotSuggestion);
         jsonObject.addProperty("consistent_previous_offer", consistent);
         jsonObject.addProperty("login", login);
         return jsonObject;

--- a/src/main/java/com/flippingcopilot/model/TransactionManger.java
+++ b/src/main/java/com/flippingcopilot/model/TransactionManger.java
@@ -84,7 +84,9 @@ public class TransactionManger {
         if (OfferStatus.SELL.equals(transaction.getType())) {
             profit.setValue(flipManager.estimateTransactionProfit(displayName, transaction));
         }
-        scheduleSyncIn(0, displayName);
+        if (loginResponseManager.isLoggedIn()) {
+            scheduleSyncIn(0, displayName);
+        }
         return profit.getValue();
     }
 
@@ -95,7 +97,7 @@ public class TransactionManger {
     public synchronized void scheduleSyncIn(int seconds, String displayName) {
         AtomicBoolean scheduled = transactionSyncScheduled.computeIfAbsent(displayName, k -> new AtomicBoolean(false));
         if(scheduled.compareAndSet(false, true)) {
-            log.info("scheduling attempt to sync {} transactions in {}s", displayName, seconds);
+            log.info("scheduling {} attempt to sync {} transactions in {}s", displayName, getUnAckedTransactions(displayName).size(), seconds);
             executorService.schedule(() ->  {
                 this.syncUnAckedTransactions(displayName);
             }, seconds, TimeUnit.SECONDS);

--- a/src/main/java/com/flippingcopilot/ui/StatsPanelV2.java
+++ b/src/main/java/com/flippingcopilot/ui/StatsPanelV2.java
@@ -62,7 +62,7 @@ public class StatsPanelV2 extends JPanel {
     private JComboBox<String> timeIntervalDropdown;
     private final DefaultComboBoxModel<String> rsAccountDropdownModel = new DefaultComboBoxModel<>();
     private final JComboBox<String> rsAccountDropdown = new JComboBox<>(rsAccountDropdownModel);
-    private final JButton sessionResetButton = new JButton("  reset  ");
+    private final JButton sessionResetButton = new JButton("  Reset session ");
     private JPanel profitAndSubInfoPanel;
     private JPanel subInfoPanel;
     private final JPanel flipsPanel = new JPanel();


### PR DESCRIPTION
  - Include new rs accounts in display name drop down.
  - Don't refersh stats panel if session stats haven't changed
  - Show item icon next to the suggestion
  - Rename 'reset' button to 'reset session'
  - Better handle when copilot isn't logged in
  - Deduplicate saved transactions on loading
  - Ensure when GE is opened or closed a new suggestion is fetched to support buy activities only being created when at GE
  - Add was_copilot_suggestion flag and propagate to transactions