### PR TITLE
Client bugfixes

### DIFF
--- a/src/main/java/com/flippingcopilot/controller/GrandExchangeOfferEventHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/GrandExchangeOfferEventHandler.java
@@ -61,7 +61,7 @@ public class GrandExchangeOfferEventHandler {
         SavedOffer prev = offerPersistence.loadOffer(accountHash, slot);
 
         if(Objects.equals(o, prev)) {
-            log.debug("skipping duplicate offer event");
+            log.debug("skipping duplicate offer event {}", o);
             return;
         }
 

--- a/src/main/java/com/flippingcopilot/controller/SuggestionController.java
+++ b/src/main/java/com/flippingcopilot/controller/SuggestionController.java
@@ -67,7 +67,7 @@ public class SuggestionController {
         // In such a case we can end up with the uncollectedManager falsely thinking there is items to collect.
         // We identify if this has happened here by checking if the collect button is actually visible.
         if(isUncollectedOutOfSync()) {
-            log.warn("uncollectedManager manager is out of sync, it thinks there are items to collect but the GE is open and the Collect button not visible");
+            log.warn("uncollected is out of sync, it thinks there are items to collect but the GE is open and the Collect button not visible");
             uncollectedManager.clearAllUncollected(osrsLoginManager.getAccountHash());
             suggestionManager.setSuggestionNeeded(true);
         }
@@ -84,14 +84,13 @@ public class SuggestionController {
         if (client.getTickCount() <= uncollectedManager.getLastUncollectedAddedTick() + 2) {
             return false;
         }
-        if(!grandExchange.isOpen() || grandExchange.isCollectButtonVisible()) {
+        if(!grandExchange.isHomeScreenOpen() || grandExchange.isCollectButtonVisible()) {
             return false;
         }
         if(uncollectedManager.HasUncollected(osrsLoginManager.getAccountHash())) {
             return true;
         }
         if(suggestionPanel.isCollectItemsSuggested()) {
-            log.debug("inner suggestion text is collect items");
             return true;
         }
         return false;

--- a/src/main/java/com/flippingcopilot/model/AccountStatus.java
+++ b/src/main/java/com/flippingcopilot/model/AccountStatus.java
@@ -80,6 +80,7 @@ public class AccountStatus {
         if(sellOnlyMode) {
             requestedSuggestionTypes.clear();
             requestedSuggestionTypes.add("abort");
+            requestedSuggestionTypes.add("sell");
         }
         if(!requestedSuggestionTypes.isEmpty()) {
            JsonArray rstArray = new JsonArray();

--- a/src/main/java/com/flippingcopilot/model/FlipManager.java
+++ b/src/main/java/com/flippingcopilot/model/FlipManager.java
@@ -94,7 +94,7 @@ public class FlipManager {
         if (Objects.equals(displayName, intervalDisplayName)) {
             return;
         }
-        if (!displayNameToAccountId.containsKey(displayName)) {
+        if (displayName != null && !displayNameToAccountId.containsKey(displayName)) {
             displayNameToAccountId.put(displayName, -1);
         }
         intervalDisplayName = displayName;

--- a/src/main/java/com/flippingcopilot/model/SavedOffer.java
+++ b/src/main/java/com/flippingcopilot/model/SavedOffer.java
@@ -63,7 +63,7 @@ public class SavedOffer
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		SavedOffer that = (SavedOffer) o;
-		return itemId == that.itemId && quantitySold == that.quantitySold && totalQuantity == that.totalQuantity && price == that.price && spent == that.spent && copilotPriceUsed == that.copilotPriceUsed && state == that.state && wasCopilotSuggestion == that.wasCopilotSuggestion;
+		return itemId == that.itemId && quantitySold == that.quantitySold && totalQuantity == that.totalQuantity && price == that.price && spent == that.spent && state == that.state;
 	}
 
 	@Override


### PR DESCRIPTION
1. Include 'sell' in the requestedSuggestionTypes when sell only mode is active. This fixes a bug where sell only mode wouldn't create new sell activities.
2. Ensure 'null' is not added to `FlipManager.displayNameToAccountId` map. This was causing the 'All accounts' option to be broken.
3. Don't include flags in `SavedOffer.equals` method. This was causing duplicate offer events to not be filtered out. Leading to duplicate amounts being added to the uncollected manager when aborting offers and leading to suggestions for wrong quantities.
4. Fix logic in `isUncollectedOutOfSync` method - the GE home screen must be open not just GE for the collect button to be visible. This was causing false positives of the function `isUncollectedOutOfSync`. (I believe this may fix an existing issue where occasionally instead of suggesting to sell an item just bought a buy suggestion for a new item will be suggested instead).