### PR TITLE
Small Mis-Click Fix: detects if the GE is open before overriding `confirm` menu option

### DIFF
--- a/src/main/java/com/flippingcopilot/controller/MenuHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/MenuHandler.java
@@ -58,6 +58,10 @@ public class MenuHandler {
             return;
         }
 
+        if (!grandExchange.isOpen()) {
+            return;
+        }
+
         if(offerDetailsCorrect()) {
             return;
         }


### PR DESCRIPTION
I noticed that the Exam random event's `Confirm` menu action was improperly deprioritized and the "Nothing" entry was auto-selected instead, I suspect this may also happen in other places. 

<img width="878" height="288" alt="image" src="https://github.com/user-attachments/assets/5955bef5-5492-4824-a5ca-895396e705ef" />