### PR TITLE
Fix incorrect total offer quantity in profit calculation

### DIFF
--- a/src/main/java/com/flippingcopilot/controller/TooltipController.java
+++ b/src/main/java/com/flippingcopilot/controller/TooltipController.java
@@ -112,7 +112,8 @@ public class TooltipController {
                     }
 
                     if(flip.getCachedItemName().equals(itemName)) {
-                        return ((long) getPostTaxPrice(offer.getItemId(), offer.getPrice()) * offer.getTotalQuantity()) - (flip.getAvgBuyPrice() * offer.getTotalQuantity());
+                        int remainingQuantity = offer.getTotalQuantity() - offer.getQuantitySold();
+                        return ((long) getPostTaxPrice(offer.getItemId(), offer.getPrice()) * remainingQuantity) - (flip.getAvgBuyPrice() * remainingQuantity);
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://discord.com/channels/1208453764630057010/1440277923260137545

Profit calculations were incorrectly using the total offer quantity instead of the remaining unsold quantity, causing profit/loss values to be doubled (or incorrect).

Root Cause: In TooltipController.java line 115, the profit calculation was using offer.getTotalQuantity() which represents the entire offer size (e.g., 16 rings) instead of just the remaining unsold items (e.g., 8 rings if 8 were already sold).

Solution: Changed the calculation to use remainingQuantity = offer.getTotalQuantity() - offer.getQuantitySold() to ensure profit is only calculated for items that haven't been sold yet.

This fix ensures the tooltip profit display correctly reflects only the profit from items currently available to sell, not the entire historical offer size. This matches the logic already used in FlipV2.calculateProfit() which correctly uses openedQuantity - closedQuantity.