### PR TITLE
Add sidebar price graph configuration and UI components

### DIFF
--- a/src/main/java/com/flippingcopilot/config/FlippingCopilotConfig.java
+++ b/src/main/java/com/flippingcopilot/config/FlippingCopilotConfig.java
@@ -6,6 +6,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.config.Range;
 import net.runelite.client.ui.ColorScheme;
 
 import java.awt.*;
@@ -133,6 +134,48 @@ public interface FlippingCopilotConfig extends Config
             position = 2
     )
     String appearanceSection = "appearanceSection";
+
+    @ConfigSection(
+            name = "Sidebar price graph",
+            description = "Configure the price graph shown in the sidebar for the current suggestion",
+            position = 21
+    )
+    String sidebarGraphSection = "sidebarGraphSection";
+
+    @ConfigItem(
+            keyName = "sidebarGraphEnabled",
+            name = "Show sidebar price graph",
+            description = "Show a compact price graph in the sidebar for the current suggestion.",
+            section = sidebarGraphSection,
+            position = 1
+    )
+    default boolean sidebarGraphEnabled() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "sidebarGraphMinutesBefore",
+            name = "Minutes before now",
+            description = "How many minutes before the current time to show on the sidebar graph.",
+            section = sidebarGraphSection,
+            position = 2
+    )
+    @Range(min = 15, max = 180)
+    default int sidebarGraphMinutesBefore() {
+        return 60;
+    }
+
+    @ConfigItem(
+            keyName = "sidebarGraphMinutesAfter",
+            name = "Minutes after now",
+            description = "How many minutes after the current time to show on the sidebar graph.",
+            section = sidebarGraphSection,
+            position = 3
+    )
+    @Range(min = 15, max = 180)
+    default int sidebarGraphMinutesAfter() {
+        return 60;
+    }
 
     @ConfigItem(
             keyName = "priceGraphMenuOptionEnabled",

--- a/src/main/java/com/flippingcopilot/controller/ApiRequestHandler.java
+++ b/src/main/java/com/flippingcopilot/controller/ApiRequestHandler.java
@@ -45,7 +45,6 @@ public class ApiRequestHandler {
     private final SuggestionPreferencesManager preferencesManager;
     private final ClientThread clientThread;
 
-
     public void authenticate(String username, String password, Consumer<LoginResponse> successCallback, Consumer<String> failureCallback) {
         Request request = new Request.Builder()
                 .url(serverUrl + "/login")

--- a/src/main/java/com/flippingcopilot/controller/FlippingCopilotPlugin.java
+++ b/src/main/java/com/flippingcopilot/controller/FlippingCopilotPlugin.java
@@ -366,6 +366,9 @@ public class FlippingCopilotPlugin extends Plugin {
 					highlightController.redraw();
 				});
 			}
+			if (event.getKey().equals("sidebarGraphEnabled") || event.getKey().equals("sidebarGraphMinutesBefore") || event.getKey().equals("sidebarGraphMinutesAfter")) {
+				clientThread.invokeLater(() -> mainPanel.copilotPanel.refresh());
+			}
 		}
 	}
 

--- a/src/main/java/com/flippingcopilot/controller/SuggestionController.java
+++ b/src/main/java/com/flippingcopilot/controller/SuggestionController.java
@@ -63,11 +63,11 @@ public class SuggestionController {
         if (pausedManager.isPaused()) {
             pausedManager.setPaused(false);
             suggestionManager.setSuggestionNeeded(true);
-            suggestionPanel.refresh();
+            copilotPanel.refresh();
         } else {
             pausedManager.setPaused(true);
             highlightController.removeAll();
-            suggestionPanel.refresh();
+            copilotPanel.refresh();
         }
     }
 
@@ -151,7 +151,11 @@ public class SuggestionController {
         suggestionManager.setGraphDataReadingInProgress(!skipGraphData);
         Consumer<Suggestion> suggestionConsumer = (newSuggestion) -> handleSuggestionReceived(oldSuggestion, newSuggestion, accountStatus);
         Consumer<Data> graphDataConsumer = (d) -> {
-            SwingUtilities.invokeLater(() -> flipDialogController.priceGraphPanel.setSuggestionPriceData(d));
+            SwingUtilities.invokeLater(() -> {
+                suggestionManager.setSuggestionGraphData(d);
+                flipDialogController.priceGraphPanel.setSuggestionPriceData(d);
+                copilotPanel.refresh();
+            });
             suggestionManager.setGraphDataReadingInProgress(false);
         };
         Consumer<HttpResponseException> onFailure = (e) -> {
@@ -164,10 +168,10 @@ public class SuggestionController {
                 mainPanel.refresh();
                 loginPanel.showLoginErrorMessage("Login timed out. Please log in again");
             } else {
-                suggestionPanel.refresh();
+                copilotPanel.refresh();
             }
         };
-        suggestionPanel.refresh();
+        copilotPanel.refresh();
         log.debug("tick {} getting suggestion", client.getTickCount());
         apiRequestHandler.getSuggestionAsync(accountStatus.toJson(gson, grandExchange.isOpen(), config.priceGraphWebsite() == FlippingCopilotConfig.PriceGraphWebsite.FLIPPING_COPILOT), suggestionConsumer, graphDataConsumer, onFailure, skipGraphData);
     }
@@ -205,7 +209,7 @@ public class SuggestionController {
         log.debug("Received suggestion: {}", newSuggestion.toString());
         accountStatusManager.resetSkipSuggestion();
         offerManager.setOfferJustPlaced(false);
-        suggestionPanel.refresh();
+        copilotPanel.refresh();
         showNotifications(oldSuggestion, newSuggestion, accountStatus);
         if (!newSuggestion.isWaitSuggestion()) {
             SwingUtilities.invokeLater(() -> flipDialogController.priceGraphPanel.newSuggestedItemId(

--- a/src/main/java/com/flippingcopilot/model/SuggestionManager.java
+++ b/src/main/java/com/flippingcopilot/model/SuggestionManager.java
@@ -1,5 +1,6 @@
 package com.flippingcopilot.model;
 
+import com.flippingcopilot.ui.graph.model.Data;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -17,6 +18,7 @@ public class SuggestionManager {
     private Instant lastFailureAt;
     private HttpResponseException suggestionError;
     private Suggestion suggestion;
+    private volatile Data suggestionGraphData;
     private Instant suggestionReceivedAt;
     private int lastOfferSubmittedTick = -1;
 
@@ -33,7 +35,9 @@ public class SuggestionManager {
     public void setSuggestion(Suggestion suggestion) {
         this.suggestion = suggestion;
         suggestionReceivedAt = Instant.now();
-
+        if (suggestion == null || suggestion.isWaitSuggestion()) {
+            this.suggestionGraphData = null;
+        }
     }
 
     public void setSuggestionError(HttpResponseException error) {
@@ -44,6 +48,7 @@ public class SuggestionManager {
     public void reset() {
         suggestionNeeded = false;
         suggestion = null;
+        suggestionGraphData = null;
         suggestionReceivedAt = null;
         lastFailureAt = null;
         lastOfferSubmittedTick = -1;

--- a/src/main/java/com/flippingcopilot/ui/CopilotPanel.java
+++ b/src/main/java/com/flippingcopilot/ui/CopilotPanel.java
@@ -1,5 +1,7 @@
 package com.flippingcopilot.ui;
 
+import com.flippingcopilot.config.FlippingCopilotConfig;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.swing.*;
@@ -11,14 +13,20 @@ public class CopilotPanel extends JPanel {
     public final SuggestionPanel suggestionPanel;
     public final StatsPanelV2 statsPanel;
     public final ControlPanel controlPanel;
+    public final SidebarGraphPanel sidebarGraphPanel;
+    private final FlippingCopilotConfig config;
 
     @Inject
     public CopilotPanel(SuggestionPanel suggestionPanel,
                         StatsPanelV2 statsPanel,
-                        ControlPanel controlPanel) {
+                        ControlPanel controlPanel,
+                        SidebarGraphPanel sidebarGraphPanel,
+                        FlippingCopilotConfig config) {
         this.statsPanel = statsPanel;
         this.suggestionPanel = suggestionPanel;
         this.controlPanel = controlPanel;
+        this.sidebarGraphPanel = sidebarGraphPanel;
+        this.config = config;
 
         setLayout(new BorderLayout());
 
@@ -28,7 +36,10 @@ public class CopilotPanel extends JPanel {
         topPanel.add(Box.createRigidArea(new Dimension(MainPanel.CONTENT_WIDTH, 5)));
         topPanel.add(controlPanel);
         topPanel.add(Box.createRigidArea(new Dimension(MainPanel.CONTENT_WIDTH, 5)));
+        topPanel.add(sidebarGraphPanel);
+        topPanel.add(Box.createRigidArea(new Dimension(MainPanel.CONTENT_WIDTH, 5)));
 
+        sidebarGraphPanel.setVisible(config.sidebarGraphEnabled());
         add(topPanel, BorderLayout.NORTH);
         add(statsPanel, BorderLayout.CENTER);
     }
@@ -39,7 +50,9 @@ public class CopilotPanel extends JPanel {
             SwingUtilities.invokeLater(this::refresh);
             return;
         }
+        sidebarGraphPanel.setVisible(config.sidebarGraphEnabled());
         suggestionPanel.refresh();
         controlPanel.refresh();
+        sidebarGraphPanel.refresh();
     }
 }

--- a/src/main/java/com/flippingcopilot/ui/SidebarGraphPanel.java
+++ b/src/main/java/com/flippingcopilot/ui/SidebarGraphPanel.java
@@ -1,0 +1,176 @@
+package com.flippingcopilot.ui;
+
+import com.flippingcopilot.config.FlippingCopilotConfig;
+import com.flippingcopilot.manager.PriceGraphConfigManager;
+import com.flippingcopilot.model.Suggestion;
+import com.flippingcopilot.model.SuggestionManager;
+import com.flippingcopilot.ui.graph.DataManager;
+import com.flippingcopilot.ui.graph.GraphPanel;
+import com.flippingcopilot.ui.graph.model.Data;
+import com.flippingcopilot.ui.graph.model.PriceLine;
+import net.runelite.client.ui.ColorScheme;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.swing.*;
+import java.awt.*;
+
+@Singleton
+public class SidebarGraphPanel extends JPanel {
+
+    private static final int SIDEBAR_GRAPH_HEIGHT = 200;
+
+    private final SuggestionManager suggestionManager;
+    private final FlippingCopilotConfig config;
+    private final GraphPanel graphPanel;
+    private final JPanel contentPanel;
+    private final CardLayout cardLayout = new CardLayout();
+    private final JPanel loadingPanel;
+    private final JPanel emptyPanel;
+
+    private static final String CARD_GRAPH = "graph";
+    private static final String CARD_LOADING = "loading";
+    private static final String CARD_EMPTY = "empty";
+
+    /** Cached so we only create a new DataManager when graph data or suggestion actually changed. */
+    private int lastGraphDataItemId = -1;
+    private Integer lastSuggestionPrice = null;
+    private Boolean lastSuggestionWasBuy = null;
+
+    @Inject
+    public SidebarGraphPanel(SuggestionManager suggestionManager,
+                             PriceGraphConfigManager configManager,
+                             FlippingCopilotConfig config) {
+        this.suggestionManager = suggestionManager;
+        this.config = config;
+        setLayout(new BorderLayout());
+        setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+        graphPanel = new GraphPanel(configManager, true);
+        graphPanel.setPreferredSize(new Dimension(MainPanel.CONTENT_WIDTH, SIDEBAR_GRAPH_HEIGHT));
+        graphPanel.setMinimumSize(new Dimension(MainPanel.CONTENT_WIDTH, SIDEBAR_GRAPH_HEIGHT));
+        graphPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, SIDEBAR_GRAPH_HEIGHT));
+
+        contentPanel = new JPanel(cardLayout);
+        contentPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        contentPanel.setPreferredSize(new Dimension(MainPanel.CONTENT_WIDTH, SIDEBAR_GRAPH_HEIGHT));
+        contentPanel.setMinimumSize(new Dimension(MainPanel.CONTENT_WIDTH, SIDEBAR_GRAPH_HEIGHT));
+
+        JPanel graphWrapper = new JPanel(new BorderLayout());
+        graphWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        graphWrapper.setOpaque(true);
+        graphWrapper.add(graphPanel, BorderLayout.CENTER);
+        contentPanel.add(graphWrapper, CARD_GRAPH);
+
+        loadingPanel = buildLoadingPanel();
+        contentPanel.add(loadingPanel, CARD_LOADING);
+
+        emptyPanel = buildEmptyPanel();
+        contentPanel.add(emptyPanel, CARD_EMPTY);
+
+        add(contentPanel, BorderLayout.CENTER);
+        cardLayout.show(contentPanel, CARD_EMPTY);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        Dimension pref = super.getPreferredSize();
+        Container parent = getParent();
+        if (parent != null && parent.getWidth() > 0) {
+            int w = Math.max(parent.getWidth(), MainPanel.CONTENT_WIDTH);
+            pref = new Dimension(w, pref.height);
+        }
+        return pref;
+    }
+
+    private JPanel buildLoadingPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        panel.setPreferredSize(new Dimension(MainPanel.CONTENT_WIDTH, SIDEBAR_GRAPH_HEIGHT));
+        JLabel label = new JLabel("Loading price graph...");
+        label.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+        Spinner spinner = new Spinner();
+        spinner.show();
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.insets = new Insets(0, 0, 8, 0);
+        panel.add(spinner, gbc);
+        gbc.gridy = 1;
+        panel.add(label, gbc);
+        return panel;
+    }
+
+    private JPanel buildEmptyPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        panel.setPreferredSize(new Dimension(MainPanel.CONTENT_WIDTH, SIDEBAR_GRAPH_HEIGHT));
+        JLabel label = new JLabel("<html><center>Price graph for the<br>current suggestion<br>appears here</center></html>");
+        label.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+        label.setHorizontalAlignment(SwingConstants.CENTER);
+        panel.add(label);
+        return panel;
+    }
+
+    private static PriceLine buildPriceLine(Suggestion suggestion) {
+        if (suggestion == null) {
+            return null;
+        }
+        if (suggestion.isBuySuggestion()) {
+            return new PriceLine(
+                    suggestion.getPrice(),
+                    "Suggested buy price",
+                    false
+            );
+        }
+        if (suggestion.isSellSuggestion()) {
+            return new PriceLine(
+                    suggestion.getPrice(),
+                    "Suggested sell price",
+                    true
+            );
+        }
+        return null;
+    }
+
+    public void refresh() {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            SwingUtilities.invokeLater(this::refresh);
+            return;
+        }
+
+        graphPanel.setSidebarTimeRange(config.sidebarGraphMinutesBefore(), config.sidebarGraphMinutesAfter());
+
+        Suggestion suggestion = suggestionManager.getSuggestion();
+        Data graphData = suggestionManager.getSuggestionGraphData();
+
+        if (suggestionManager.isGraphDataReadingInProgress()) {
+            cardLayout.show(contentPanel, CARD_LOADING);
+            return;
+        }
+
+        if (suggestion != null && !suggestion.isWaitSuggestion()
+                && graphData != null && graphData.itemId == suggestion.getItemId()) {
+            int suggestionPrice = suggestion.getPrice();
+            boolean suggestionIsBuy = suggestion.isBuySuggestion();
+            boolean dataUnchanged = lastGraphDataItemId == graphData.itemId
+                    && lastSuggestionPrice != null && lastSuggestionPrice == suggestionPrice
+                    && lastSuggestionWasBuy != null && lastSuggestionWasBuy == suggestionIsBuy;
+
+            if (!dataUnchanged) {
+                lastGraphDataItemId = graphData.itemId;
+                lastSuggestionPrice = suggestionPrice;
+                lastSuggestionWasBuy = suggestionIsBuy;
+                DataManager dm = new DataManager(graphData, null);
+                PriceLine priceLine = buildPriceLine(suggestion);
+                graphPanel.setData(dm, priceLine);
+            }
+            cardLayout.show(contentPanel, CARD_GRAPH);
+        } else {
+            lastGraphDataItemId = -1;
+            lastSuggestionPrice = null;
+            lastSuggestionWasBuy = null;
+            cardLayout.show(contentPanel, CARD_EMPTY);
+        }
+    }
+}

--- a/src/main/java/com/flippingcopilot/ui/graph/AxisCalculator.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/AxisCalculator.java
@@ -101,8 +101,11 @@ public class AxisCalculator {
     }
 
     public static YAxis calculatePriceAxis(Bounds bounds) {
-        int maxAllowableTicks = 18;
-        int maxAllowableGridLines = 28;
+        return calculatePriceAxis(bounds, 18);
+    }
+
+    public static YAxis calculatePriceAxis(Bounds bounds, int maxAllowableTicks) {
+        int maxAllowableGridLines = maxAllowableTicks * 2;
 
         int priceRange = (int) bounds.yDelta();
         int priceMin = (int) bounds.yMin;

--- a/src/main/java/com/flippingcopilot/ui/graph/DataManager.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/DataManager.java
@@ -111,6 +111,35 @@ public class DataManager {
         return b;
     }
 
+    /**
+     * Bounds for the sidebar graph: from (now - minutesBefore) to (now + minutesAfter).
+     * Minutes are clamped to 1–180.
+     */
+    public Bounds calculateSidebarBounds(int minutesBefore, int minutesAfter) {
+        int before = Math.max(1, Math.min(180, minutesBefore));
+        int after = Math.max(1, Math.min(180, minutesAfter));
+        int now = (int) Instant.now().getEpochSecond();
+        int xMin = now - before * 60;
+        int xMax = now + after * 60;
+        Bounds b = calculateBounds((p) -> p.time >= xMin && p.time <= xMax);
+        b.xMin = xMin;
+        b.xMax = xMax;
+        if (b.yMin > b.yMax) {
+            b.yMin = maxBounds.yMin;
+            b.yMax = maxBounds.yMax;
+        }
+        return b;
+    }
+
+    /**
+     * Bounds for a compact "last hour + 1 hour ahead" view (e.g. sidebar).
+     * @deprecated Use {@link #calculateSidebarBounds(int, int)} with config values.
+     */
+    @Deprecated
+    public Bounds calculateLastHourBounds() {
+        return calculateSidebarBounds(60, 60);
+    }
+
     public Bounds calculateMonthBounds() {
         Bounds b = calculateBounds((p) -> p.time > maxBounds.xMax - 30 * Constants.DAY_SECONDS);
         b.xMin= ((b.xMin) / Constants.HOUR_SECONDS) * Constants.HOUR_SECONDS;

--- a/src/main/java/com/flippingcopilot/ui/graph/GraphPanel.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/GraphPanel.java
@@ -10,11 +10,22 @@ import java.awt.event.*;
 public class GraphPanel extends JPanel {
 
     private final PriceGraphConfigManager configManager;
+    private final boolean sidebarMode;
     public DataManager dataManager;
     private final RenderV2 renderer;
     public final ZoomHandler zoomHandler;
     private final DatapointTooltip tooltip;
     private PriceLine priceLine;
+
+    /** Used in sidebar mode for time range (minutes before/after now). */
+    private int sidebarMinutesBefore = 60;
+    private int sidebarMinutesAfter = 60;
+
+    /** Cached sidebar bounds to avoid recalculating every paint; invalidated when data or time range changes. */
+    private Bounds cachedSidebarBounds;
+    private long cachedSidebarBoundsMinute = -1;
+    private int cachedSidebarMinutesBefore = -1;
+    private int cachedSidebarMinutesAfter = -1;
 
     public Bounds bounds;
 
@@ -25,7 +36,11 @@ public class GraphPanel extends JPanel {
     private Datapoint hoveredPoint = null;
 
     public GraphPanel(PriceGraphConfigManager configManager) {
+        this(configManager, false);
+    }
 
+    public GraphPanel(PriceGraphConfigManager configManager, boolean sidebarMode) {
+        this.sidebarMode = sidebarMode;
         this.configManager = configManager;
         this.renderer = new RenderV2();
         this.zoomHandler = new ZoomHandler();
@@ -33,7 +48,7 @@ public class GraphPanel extends JPanel {
 
         setBackground(configManager.getConfig().backgroundColor);
         setPreferredSize(new Dimension(500, 300));
-        setBorder(BorderFactory.createEmptyBorder(0, 10, 10, 10));
+        setBorder(BorderFactory.createEmptyBorder(0, sidebarMode ? 4 : 10, sidebarMode ? 4 : 10, sidebarMode ? 4 : 10));
         setupMouseListeners();
     }
 
@@ -45,14 +60,28 @@ public class GraphPanel extends JPanel {
         int oldItemID = dataManager == null ? -1 : dataManager.data.itemId;
         dataManager = dm;
         this.priceLine = priceLine;
+        cachedSidebarBounds = null;
         zoomHandler.maxViewBounds = dataManager.maxBounds;
-        zoomHandler.homeViewBounds = dataManager.calculateHomeBounds();
+        if (sidebarMode) {
+            zoomHandler.homeViewBounds = dataManager.calculateSidebarBounds(sidebarMinutesBefore, sidebarMinutesAfter);
+        } else {
+            zoomHandler.homeViewBounds = dataManager.calculateHomeBounds();
+        }
         zoomHandler.weekViewBounds = dataManager.calculateWeekBounds();
         zoomHandler.monthViewBounds = dataManager.calculateMonthBounds();
-        if (oldItemID != dataManager.data.itemId) {
+        if (sidebarMode || oldItemID != dataManager.data.itemId) {
             bounds = zoomHandler.homeViewBounds.copy();
         }
         repaint();
+    }
+
+    /**
+     * Sets the sidebar graph time range (minutes before and after now). Only used when in sidebar mode.
+     */
+    public void setSidebarTimeRange(int minutesBefore, int minutesAfter) {
+        this.sidebarMinutesBefore = minutesBefore;
+        this.sidebarMinutesAfter = minutesAfter;
+        cachedSidebarBounds = null;
     }
 
 
@@ -76,7 +105,7 @@ public class GraphPanel extends JPanel {
 
             @Override
             public void mousePressed(MouseEvent e) {
-                if(dataManager == null){
+                if (dataManager == null) {
                     return;
                 }
                 mousePosition = e.getPoint();
@@ -84,50 +113,51 @@ public class GraphPanel extends JPanel {
                     return;
                 }
 
-                if (zoomHandler.isOverHomeButton(mousePosition)) {
-                    zoomHandler.applyHomeView(bounds);
-                    repaint();
-                    return;
+                if (!sidebarMode) {
+                    if (zoomHandler.isOverHomeButton(mousePosition)) {
+                        zoomHandler.applyHomeView(bounds);
+                        repaint();
+                        return;
+                    }
+                    if (zoomHandler.isOverMaxButton(mousePosition)) {
+                        zoomHandler.applyMaxView(bounds);
+                        repaint();
+                        return;
+                    }
+                    if (zoomHandler.isOverZoomInButton(mousePosition)) {
+                        zoomHandler.applyZoomIn(bounds);
+                        repaint();
+                        return;
+                    }
+                    if (zoomHandler.isOverZoomOutButton(mousePosition)) {
+                        zoomHandler.applyZoomOut(bounds);
+                        repaint();
+                        return;
+                    }
+                    if (zoomHandler.isOverWeekButton(mousePosition)) {
+                        zoomHandler.applyWeekView(bounds);
+                        repaint();
+                        return;
+                    }
+                    if (zoomHandler.isOverMonthButton(mousePosition)) {
+                        zoomHandler.applyMonthView(bounds);
+                        repaint();
+                        return;
+                    }
+                    zoomHandler.startSelection(mousePosition);
+                    setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
                 }
-                if (zoomHandler.isOverMaxButton(mousePosition)) {
-                    zoomHandler.applyMaxView(bounds);
-                    repaint();
-                    return;
-                }
-                if (zoomHandler.isOverZoomInButton(mousePosition)) {
-                    zoomHandler.applyZoomIn(bounds);
-                    repaint();
-                    return;
-                }
-                if (zoomHandler.isOverZoomOutButton(mousePosition)) {
-                    zoomHandler.applyZoomOut(bounds);
-                    repaint();
-                    return;
-                }
-                if (zoomHandler.isOverWeekButton(mousePosition)) {
-                    zoomHandler.applyWeekView(bounds);
-                    repaint();
-                    return;
-                }
-                if (zoomHandler.isOverMonthButton(mousePosition)) {
-                    zoomHandler.applyMonthView(bounds);
-                    repaint();
-                    return;
-                }
-
-                zoomHandler.startSelection(mousePosition);
                 hoveredPoint = null;
-                setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
                 repaint();
             }
 
             @Override
             public void mouseDragged(MouseEvent e) {
-                if(dataManager == null){
+                if (dataManager == null) {
                     return;
                 }
                 mousePosition = e.getPoint();
-                if (zoomHandler.isSelecting()) {
+                if (!sidebarMode && zoomHandler.isSelecting()) {
                     zoomHandler.setSelectionEnd(mousePosition);
                     repaint();
                 }
@@ -135,11 +165,11 @@ public class GraphPanel extends JPanel {
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                if(dataManager == null){
+                if (dataManager == null) {
                     return;
                 }
                 mousePosition = e.getPoint();
-                if (zoomHandler.isSelecting()) {
+                if (!sidebarMode && zoomHandler.isSelecting()) {
                     setCursor(Cursor.getDefaultCursor());
                     zoomHandler.setSelectionEnd(mousePosition);
                     zoomHandler.applySelection(pricePa, bounds);
@@ -167,24 +197,38 @@ public class GraphPanel extends JPanel {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
 
+        final int leftPadding = sidebarMode ? 36 : 80;
+        final int topPadding = sidebarMode ? 8 : 50;
+        final int rightPadding = sidebarMode ? 6 : 20;
+        final int bottomPadding = sidebarMode ? 20 : 50;
 
-        final int leftPadding = 80;
-        final int topPadding = 50;
-        final int rightPadding = 20;
-        final int bottomPadding = 50;
-        
         int w = getWidth() - leftPadding - rightPadding;
         int ah = getHeight() - topPadding - bottomPadding;
-        int h1 = (int) (ah * 0.75);
+        int h1 = sidebarMode ? ah : (int) (ah * 0.75);
         int h2 = ah - h1;
-        
+
         pricePa = new Rectangle(leftPadding, topPadding, w, h1);
-        volumePa = new Rectangle(leftPadding, topPadding+h1, w, h2);
-        if(dataManager == null) {
+        volumePa = new Rectangle(leftPadding, topPadding + h1, w, h2);
+        if (dataManager == null) {
             return;
         }
         Data data = dataManager.getData();
         if (data == null) return;
+
+        if (sidebarMode) {
+            long nowMinute = System.currentTimeMillis() / 60000;
+            if (cachedSidebarBounds == null || cachedSidebarBoundsMinute != nowMinute
+                    || cachedSidebarMinutesBefore != sidebarMinutesBefore || cachedSidebarMinutesAfter != sidebarMinutesAfter) {
+                bounds = dataManager.calculateSidebarBounds(sidebarMinutesBefore, sidebarMinutesAfter).copy();
+                cachedSidebarBounds = bounds.copy();
+                cachedSidebarBoundsMinute = nowMinute;
+                cachedSidebarMinutesBefore = sidebarMinutesBefore;
+                cachedSidebarMinutesAfter = sidebarMinutesAfter;
+            } else {
+                bounds = cachedSidebarBounds.copy();
+            }
+        }
+
         Config config = configManager.getConfig();
         setBackground(config.backgroundColor);
         Graphics2D g2d = (Graphics2D) g;
@@ -192,92 +236,119 @@ public class GraphPanel extends JPanel {
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 
-        // First draw the legend above the plot area
-        renderer.drawLegend(g2d, config, pricePa, data.predictionTimes != null);
+        if (!sidebarMode) {
+            renderer.drawLegend(g2d, config, pricePa, data.predictionTimes != null);
+        }
 
         // Draw the plot area background with dynamic padding
-        g2d.setColor(config.plotAreaColor);
+        g2d.setColor(sidebarMode ? Config.SIDEBAR_PLOT_AREA_COLOR : config.plotAreaColor);
         g2d.fillRect(pricePa.x, pricePa.y, pricePa.width, pricePa.height);
-        g2d.fillRect(volumePa.x, volumePa.y,  volumePa.width, volumePa.height);
-        
+        if (!sidebarMode) {
+            g2d.fillRect(volumePa.x, volumePa.y, volumePa.width, volumePa.height);
+        }
+
         TimeAxis xAxis = AxisCalculator.calculateTimeAxis(bounds, AxisCalculator.getLocalTimeOffsetSeconds());
-        YAxis yAxis = AxisCalculator.calculatePriceAxis(bounds);
+        YAxis yAxis = AxisCalculator.calculatePriceAxis(bounds, sidebarMode ? 5 : 18);
         YAxis y2Axis = AxisCalculator.calculateVolumeAxis(bounds);
 
-        renderer.drawGrid(g2d, config, pricePa, bounds, bounds::toY, xAxis, yAxis);
-        renderer.drawGrid(g2d, config, volumePa, bounds, bounds:: toY2, xAxis, y2Axis);
-        renderer.drawAxes(g2d, config, pricePa);
-        renderer.drawYAxisLabels(g2d, config, pricePa, bounds::toY, yAxis, false);
-        renderer.drawAxes(g2d, config, volumePa);
-        renderer.drawYAxisLabels(g2d, config, volumePa, bounds::toY2, y2Axis, true);
-        renderer.drawXAxisLabels(g2d, config, volumePa, bounds, xAxis);
-
+        renderer.drawGrid(g2d, config, pricePa, bounds, bounds::toY, xAxis, yAxis,
+                sidebarMode ? Config.SIDEBAR_GRID_COLOR : null,
+                sidebarMode ? Config.SIDEBAR_GRID_STROKE : null);
+        if (!sidebarMode) {
+            renderer.drawGrid(g2d, config, volumePa, bounds, bounds::toY2, xAxis, y2Axis);
+        }
+        renderer.drawAxes(g2d, config, pricePa, sidebarMode ? Config.SIDEBAR_AXIS_COLOR : null);
+        float axisFontSize = sidebarMode ? 12f : Config.FONT_SIZE;
+        Color axisLabelColor = sidebarMode ? Config.SIDEBAR_TEXT_COLOR : null;
+        renderer.drawYAxisLabels(g2d, config, pricePa, bounds::toY, yAxis, false, axisFontSize, axisLabelColor);
+        if (!sidebarMode) {
+            renderer.drawAxes(g2d, config, volumePa);
+            renderer.drawYAxisLabels(g2d, config, volumePa, bounds::toY2, y2Axis, true);
+        }
+        renderer.drawXAxisLabels(g2d, config, sidebarMode ? pricePa : volumePa, bounds, xAxis, axisFontSize, axisLabelColor);
 
         int pointSize = dynamicPointSize(Config.BASE_POINT_SIZE, bounds);
-        renderer.drawPoints(g2d, pricePa, bounds, dataManager.lowDatapoints, config.lowColor, pointSize);
-        renderer.drawPoints(g2d, pricePa, bounds, dataManager.highDatapoints, config.highColor, pointSize);
-        if (config.connectPoints) {
-            renderer.drawLines(g2d, pricePa, bounds, dataManager.lowDatapoints, config.lowColor, Config.NORMAL_STROKE);
-            renderer.drawLines(g2d, pricePa, bounds, dataManager.highDatapoints, config.highColor, Config.NORMAL_STROKE);
+        if (sidebarMode) {
+            pointSize = Math.max(pointSize, 6);
+        }
+        Color highColor = sidebarMode ? Config.SIDEBAR_HIGH_COLOR : config.highColor;
+        Color lowColor = sidebarMode ? Config.SIDEBAR_LOW_COLOR : config.lowColor;
+        renderer.drawPoints(g2d, pricePa, bounds, dataManager.lowDatapoints, lowColor, pointSize);
+        renderer.drawPoints(g2d, pricePa, bounds, dataManager.highDatapoints, highColor, pointSize);
+        Stroke dataLineStroke = sidebarMode ? Config.SIDEBAR_LINE_STROKE : Config.NORMAL_STROKE;
+        if (config.connectPoints || sidebarMode) {
+            renderer.drawLines(g2d, pricePa, bounds, dataManager.lowDatapoints, lowColor, dataLineStroke);
+            renderer.drawLines(g2d, pricePa, bounds, dataManager.highDatapoints, highColor, dataLineStroke);
         }
         renderer.drawStartPoints(g2d, pricePa, bounds, dataManager.buyPriceDataPoint(), Color.WHITE, pointSize);
         renderer.drawStartPoints(g2d, pricePa, bounds, dataManager.sellPriceDataPoint(), Color.WHITE, pointSize);
         if (config.showSuggestedPriceLines) {
-            drawSuggestedPriceLine(g2d, config);
+            drawSuggestedPriceLine(g2d, config, axisFontSize);
         }
 
-        renderer.drawLines(g2d, pricePa, bounds, dataManager.predictionLowDatapoints, config.lowColor, Config.DOTTED_STROKE);
-        renderer.drawLines(g2d, pricePa, bounds, dataManager.predictionHighDatapoints, config.highColor, Config.DOTTED_STROKE);
-        if(data.predictionTimes != null) {
+        renderer.drawLines(g2d, pricePa, bounds, dataManager.predictionLowDatapoints,
+                sidebarMode ? Config.SIDEBAR_LOW_COLOR : config.lowColor,
+                sidebarMode ? Config.SIDEBAR_LINE_STROKE : Config.DOTTED_STROKE);
+        renderer.drawLines(g2d, pricePa, bounds, dataManager.predictionHighDatapoints,
+                sidebarMode ? Config.SIDEBAR_HIGH_COLOR : config.highColor,
+                sidebarMode ? Config.SIDEBAR_LINE_STROKE : Config.DOTTED_STROKE);
+        if (data.predictionTimes != null && !sidebarMode) {
             renderer.drawPredictionIQR(g2d, config, pricePa, bounds, data.predictionTimes, data.predictionLowIQRLower, data.predictionLowIQRUpper, true);
             renderer.drawPredictionIQR(g2d, config, pricePa, bounds, data.predictionTimes, data.predictionHighIQRLower, data.predictionHighIQRUpper, false);
         }
-        zoomHandler.drawButtons(g2d, pricePa, mousePosition);
-        zoomHandler.drawSelectionRectangle(g2d, pricePa);
+        if (!sidebarMode) {
+            zoomHandler.drawButtons(g2d, pricePa, mousePosition);
+            zoomHandler.drawSelectionRectangle(g2d, pricePa);
+            renderer.drawVolumeBars(g2d, config, volumePa, bounds, dataManager.volumes, hoveredPoint);
+        }
 
-        renderer.drawVolumeBars(g2d, config, volumePa, bounds, dataManager.volumes, hoveredPoint);
-
-
-        if(!this.dataManager.flipEntryDatapoints.isEmpty()) {
+        if (!this.dataManager.flipEntryDatapoints.isEmpty()) {
             renderer.drawTxsDatapoints(g2d, pricePa, bounds, this.dataManager.flipEntryDatapoints, hoveredPoint, config);
         }
 
-        if(!this.dataManager.flipCloseDatapoints.isEmpty()) {
+        if (!this.dataManager.flipCloseDatapoints.isEmpty()) {
             renderer.drawTxsDatapoints(g2d, pricePa, bounds, this.dataManager.flipCloseDatapoints, hoveredPoint, config);
         }
 
         // Draw tooltip for hovered point
         if (hoveredPoint != null) {
-            if (hoveredPoint.type == Datapoint.Type.VOLUME_1H) {
+            if (!sidebarMode && hoveredPoint.type == Datapoint.Type.VOLUME_1H) {
                 tooltip.drawVolume(g2d, config, volumePa, bounds, hoveredPoint);
-            } else {
+            } else if (hoveredPoint.type != Datapoint.Type.VOLUME_1H) {
                 tooltip.draw(g2d, config, pricePa, bounds, hoveredPoint);
             }
         }
     }
 
-    private void drawSuggestedPriceLine(Graphics2D g2d, Config config) {
+    private void drawSuggestedPriceLine(Graphics2D g2d, Config config, float labelFontSize) {
         if (priceLine == null) {
             return;
         }
         int y = bounds.toY(pricePa, priceLine.getPrice());
-        g2d.setColor(Color.WHITE);
+        g2d.setColor(sidebarMode ? Config.SIDEBAR_SUGGESTED_PRICE_LINE_COLOR : Color.WHITE);
         Stroke previousStroke = g2d.getStroke();
-        g2d.setStroke(Config.DOTTED_STROKE);
+        g2d.setStroke(sidebarMode ? Config.SIDEBAR_DOTTED_STROKE : Config.DOTTED_STROKE);
         g2d.drawLine(pricePa.x, y, pricePa.x + pricePa.width, y);
         g2d.setStroke(previousStroke);
 
+        if (sidebarMode) {
+            return;
+        }
         String label = priceLine.getMessage();
         if (label == null || label.isBlank()) {
             return;
         }
+        Font prevFont = g2d.getFont();
+        g2d.setFont(prevFont.deriveFont(labelFontSize));
         FontMetrics metrics = g2d.getFontMetrics();
         int labelWidth = metrics.stringWidth(label);
-        int labelX = pricePa.x + pricePa.width - labelWidth - Config.LABEL_PADDING;
+        int padding = Config.LABEL_PADDING;
+        int labelX = pricePa.x + pricePa.width - labelWidth - padding;
         int labelY = priceLine.isTextAbove()
-                ? Math.max(pricePa.y + metrics.getAscent(), y - (Config.LABEL_PADDING / 2))
-                : Math.min(pricePa.y + pricePa.height - Config.LABEL_PADDING, y + metrics.getAscent() + (Config.LABEL_PADDING / 2));
+                ? Math.max(pricePa.y + metrics.getAscent(), y - (padding / 2))
+                : Math.min(pricePa.y + pricePa.height - padding, y + metrics.getAscent() + (padding / 2));
         g2d.drawString(label, labelX, labelY);
+        g2d.setFont(prevFont);
     }
 
     private int dynamicPointSize(int baseSize, Bounds bounds) {

--- a/src/main/java/com/flippingcopilot/ui/graph/RenderV2.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/RenderV2.java
@@ -10,13 +10,24 @@ import java.util.function.BiFunction;
 public class RenderV2 {
 
     public void drawGrid(Graphics2D g2, Config config, Rectangle pa, Bounds bounds, BiFunction<Rectangle, Long, Integer> toY, TimeAxis xAxis, YAxis yAxis) {
-        g2.setColor(config.gridColor);
-        g2.setStroke(Config.NORMAL_STROKE);
+        drawGrid(g2, config, pa, bounds, toY, xAxis, yAxis, null);
+    }
+
+    public void drawGrid(Graphics2D g2, Config config, Rectangle pa, Bounds bounds, BiFunction<Rectangle, Long, Integer> toY, TimeAxis xAxis, YAxis yAxis, Color gridColorOverride) {
+        drawGrid(g2, config, pa, bounds, toY, xAxis, yAxis, gridColorOverride, null);
+    }
+
+    public void drawGrid(Graphics2D g2, Config config, Rectangle pa, Bounds bounds, BiFunction<Rectangle, Long, Integer> toY, TimeAxis xAxis, YAxis yAxis, Color gridColorOverride, Stroke gridStrokeOverride) {
+        Color gridColor = gridColorOverride != null ? gridColorOverride : config.gridColor;
+        Stroke gridStroke = gridStrokeOverride != null ? gridStrokeOverride : Config.NORMAL_STROKE;
+        Stroke gridLineStroke = gridStrokeOverride != null ? gridStrokeOverride : Config.GRID_STROKE;
+        g2.setColor(gridColor);
+        g2.setStroke(gridStroke);
         for (int t : xAxis.dateOnlyTickTimes) {
             int x = bounds.toX(pa,t);
             g2.drawLine(x, pa.y, x, pa.y + pa.height);
         }
-        g2.setStroke(Config.GRID_STROKE);
+        g2.setStroke(gridLineStroke);
         for (int t : xAxis.timeOnlyTickTimes) {
             int x = bounds.toX(pa,t);
             g2.drawLine(x, pa.y, x, pa.y + pa.height);
@@ -36,15 +47,28 @@ public class RenderV2 {
     }
 
     public void drawAxes(Graphics2D g2, Config config,  Rectangle pa) {
-        g2.setColor(config.axisColor);
+        drawAxes(g2, config, pa, null);
+    }
+
+    public void drawAxes(Graphics2D g2, Config config, Rectangle pa, Color axisColorOverride) {
+        Color axisColor = axisColorOverride != null ? axisColorOverride : config.axisColor;
+        g2.setColor(axisColor);
         g2.setStroke(new BasicStroke(1.0f));
         g2.drawLine(pa.x,  pa.y + pa.height, pa.x + pa.width, pa.y + pa.height);
         g2.drawLine(pa.x, pa.y, pa.x, pa.y +pa.height);
     }
 
     public void drawXAxisLabels(Graphics2D g2, Config config, Rectangle pa, Bounds bounds, TimeAxis xAxis) {
-        g2.setFont(g2.getFont().deriveFont(Config.FONT_SIZE));
-        g2.setColor(config.textColor);
+        drawXAxisLabels(g2, config, pa, bounds, xAxis, Config.FONT_SIZE);
+    }
+
+    public void drawXAxisLabels(Graphics2D g2, Config config, Rectangle pa, Bounds bounds, TimeAxis xAxis, float fontSize) {
+        drawXAxisLabels(g2, config, pa, bounds, xAxis, fontSize, null);
+    }
+
+    public void drawXAxisLabels(Graphics2D g2, Config config, Rectangle pa, Bounds bounds, TimeAxis xAxis, float fontSize, Color textColorOverride) {
+        g2.setFont(g2.getFont().deriveFont(fontSize));
+        g2.setColor(textColorOverride != null ? textColorOverride : config.textColor);
         FontMetrics metrics = g2.getFontMetrics();
 
         java.text.SimpleDateFormat dateFormat = new java.text.SimpleDateFormat("d MMM");
@@ -77,8 +101,16 @@ public class RenderV2 {
     }
 
     public void drawYAxisLabels(Graphics2D g2, Config config, Rectangle pa, BiFunction<Rectangle, Long, Integer> toY, YAxis yAxis, boolean skipLast) {
-        g2.setFont(g2.getFont().deriveFont(Config.FONT_SIZE));
-        g2.setColor(config.textColor);
+        drawYAxisLabels(g2, config, pa, toY, yAxis, skipLast, Config.FONT_SIZE, null);
+    }
+
+    public void drawYAxisLabels(Graphics2D g2, Config config, Rectangle pa, BiFunction<Rectangle, Long, Integer> toY, YAxis yAxis, boolean skipLast, float fontSize) {
+        drawYAxisLabels(g2, config, pa, toY, yAxis, skipLast, fontSize, null);
+    }
+
+    public void drawYAxisLabels(Graphics2D g2, Config config, Rectangle pa, BiFunction<Rectangle, Long, Integer> toY, YAxis yAxis, boolean skipLast, float fontSize, Color textColorOverride) {
+        g2.setFont(g2.getFont().deriveFont(fontSize));
+        g2.setColor(textColorOverride != null ? textColorOverride : config.textColor);
         FontMetrics metrics = g2.getFontMetrics();
         for (long v : yAxis.tickValues) {
             int y = toY.apply(pa, v);

--- a/src/main/java/com/flippingcopilot/ui/graph/model/Config.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/model/Config.java
@@ -26,6 +26,12 @@ public class Config {
     public static final Stroke DOTTED_STROKE = new BasicStroke(
             1.5f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[]{5}, 0
     );
+    /** Thicker stroke for sidebar graph lines (better visibility when small). */
+    public static final Stroke SIDEBAR_LINE_STROKE = new BasicStroke(2f);
+    /** Thicker dashed stroke for sidebar suggested price line. */
+    public static final Stroke SIDEBAR_DOTTED_STROKE = new BasicStroke(
+            2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[]{6}, 0
+    );
     public static final Stroke GRID_STROKE = new BasicStroke(
             0.8f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[]{3}, 0
     );
@@ -53,4 +59,20 @@ public class Config {
     public Color textColor = new Color(225, 225, 225);
     public Color axisColor = new Color(150, 150, 150);
     public Color gridColor = new Color(85, 85, 85, 90);
+
+    /** Brighter grid/axis for small sidebar graph (easier to read). */
+    public static final Color SIDEBAR_GRID_COLOR = new Color(120, 120, 120);
+    public static final Color SIDEBAR_AXIS_COLOR = new Color(200, 200, 200);
+    /** Slightly lighter plot area for sidebar so grid lines stand out. */
+    public static final Color SIDEBAR_PLOT_AREA_COLOR = new Color(55, 55, 55);
+    /** High-contrast orange for sidebar high/sell series (easier to see when small). */
+    public static final Color SIDEBAR_HIGH_COLOR = new Color(255, 140, 0);
+    /** High-contrast blue for sidebar low/buy series. */
+    public static final Color SIDEBAR_LOW_COLOR = new Color(70, 180, 255);
+    /** Bright suggested price line in sidebar (stands out from grid). */
+    public static final Color SIDEBAR_SUGGESTED_PRICE_LINE_COLOR = new Color(180, 255, 100);
+    /** Brighter axis label text in sidebar. */
+    public static final Color SIDEBAR_TEXT_COLOR = new Color(240, 240, 240);
+    /** Thicker grid stroke for sidebar (solid, more visible). */
+    public static final Stroke SIDEBAR_GRID_STROKE = new BasicStroke(1f);
 }


### PR DESCRIPTION
# Sidebar price graph

## Summary
Adds a compact price graph in the Flipping Copilot sidebar that shows recent and near-future prices for the current suggestion. Users can show/hide the graph and configure the time range (minutes before and after “now”) via plugin config.

## Changes

### Feature
- **Sidebar graph panel**  
  New `SidebarGraphPanel` shows a small price chart for the active suggestion (buy/sell), with loading and empty states. Reuses the existing `GraphPanel` in a “sidebar” mode (no volume bars, fewer axis ticks, dedicated colors and padding).
- **Config**  
  New config section “Sidebar price graph” with:
  - **Show sidebar price graph** – toggle visibility (default on).
  - **Minutes before now** / **Minutes after now** – time window for the graph (15–180 minutes each, default 60/60).
- **Data flow**  
  When the API returns suggestion + graph data, the same `Data` is stored on `SuggestionManager` and used by both the main price graph dialog and the sidebar, so no extra request is made for the sidebar.
- **Refresh behavior**  
  Sidebar visibility and time range respond immediately to config changes. Refreshes are coordinated through `CopilotPanel.refresh()` so the suggestion panel, controls, and sidebar graph stay in sync.

### Code quality
- **SidebarGraphPanel**  
  Builds a new `DataManager` only when the suggestion or graph data actually changes (cached by item id and suggestion price/type).
- **GraphPanel (sidebar mode)**  
  Sidebar time bounds are cached and only recomputed when the current minute or the before/after config changes, instead of every paint.
- **ApiRequestHandler**  
  Uses `@RequiredArgsConstructor(onConstructor_ = @Inject)` for consistency with the rest of the codebase.


<img width="235" height="482" alt="image" src="https://github.com/user-attachments/assets/73307e78-fd84-4bf8-9285-37c0171a7a04" />

<img width="233" height="179" alt="image" src="https://github.com/user-attachments/assets/ac2abe3a-f9b0-4833-a7eb-31a960a98363" />

