### PR TITLE
Show expected flip duration on Grand Exchange offer tooltips

### DIFF
--- a/src/main/java/com/flippingcopilot/controller/TooltipController.java
+++ b/src/main/java/com/flippingcopilot/controller/TooltipController.java
@@ -1,5 +1,6 @@
 package com.flippingcopilot.controller;
 
+import com.flippingcopilot.model.SuggestionManager;
 import com.flippingcopilot.ui.UIUtilities;
 import com.flippingcopilot.util.ProfitCalculator;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +23,13 @@ import java.util.regex.Pattern;
 public class TooltipController {
     private static final int SCRIPT_TOOLTIP_GE = 526;
     private static final int TOOLTIP_HEIGHT_WITH_PROFIT = 45;
+    private static final int TOOLTIP_LINE_HEIGHT = 13;
 
     private static final int WIDTH_PADDING = 4;
 
     private final Client client;
     private final ProfitCalculator profitCalculator;
+    private final SuggestionManager suggestionManager;
 
     public void tooltip(ScriptPostFired e) {
         if(e.getScriptId() != SCRIPT_TOOLTIP_GE) {
@@ -58,8 +61,17 @@ public class TooltipController {
 
             if(name != null) {
                 long profit = profitCalculator.getProfitByItemName(name);
-                text.setText(text.getText()  + "<br>Profit: " + UIUtilities.quantityToRSDecimalStack(profit, false) + " gp");
-                tooltip.setOriginalHeight(TOOLTIP_HEIGHT_WITH_PROFIT);
+                String updatedText = text.getText() + "<br>Profit: " + UIUtilities.quantityToRSDecimalStack(profit, false) + " gp";
+                int height = TOOLTIP_HEIGHT_WITH_PROFIT;
+
+                Double expectedSeconds = suggestionManager.getExpectedDurationForItem(name);
+                if (expectedSeconds != null) {
+                    updatedText += "<br>Est. time: " + UIUtilities.formatSuggestionDuration(expectedSeconds);
+                    height += TOOLTIP_LINE_HEIGHT;
+                }
+
+                text.setText(updatedText);
+                tooltip.setOriginalHeight(height);
 
                 int width = calculateTooltipWidth(text.getFont(), text.getText());
                 tooltip.setOriginalWidth(width);

--- a/src/main/java/com/flippingcopilot/model/SuggestionManager.java
+++ b/src/main/java/com/flippingcopilot/model/SuggestionManager.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 
 import javax.inject.Singleton;
 import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Singleton
 @Getter
@@ -28,13 +30,24 @@ public class SuggestionManager {
     private int suggestionItemIdOnOfferSubmitted = -1;
     private OfferStatus suggestionOfferStatusOnOfferSubmitted = null;
 
+    // Most recent expected duration (seconds) Copilot predicted for each item, captured from each
+    // suggestion as it arrives. expectedDuration only lives on the live suggestion, so caching it by
+    // item lets the GE offer tooltip show an expected time for any item that has been suggested.
+    private final Map<String, Double> itemNameToExpectedDuration = new ConcurrentHashMap<>();
+
 
     public volatile int suggestionsDelayedUntil = 0;
 
     public void setSuggestion(Suggestion suggestion) {
         this.suggestion = suggestion;
         suggestionReceivedAt = Instant.now();
+        if (suggestion != null && suggestion.getExpectedDuration() != null && suggestion.getName() != null) {
+            itemNameToExpectedDuration.put(suggestion.getName(), suggestion.getExpectedDuration());
+        }
+    }
 
+    public Double getExpectedDurationForItem(String itemName) {
+        return itemNameToExpectedDuration.get(itemName);
     }
 
     public void setSuggestionError(HttpResponseException error) {
@@ -52,6 +65,7 @@ public class SuggestionManager {
         suggestionError = null;
         suggestionItemIdOnOfferSubmitted = -1;
         suggestionOfferStatusOnOfferSubmitted = null;
+        itemNameToExpectedDuration.clear();
     }
 
     public boolean suggestionOutOfDate() {


### PR DESCRIPTION
## Summary
Surfaces Copilot's predicted flip duration as an `Est. time` line on the Grand Exchange offer-slot tooltip, right under the existing `Profit` line.

Copilot already returns an `expectedDuration` with each suggestion — it's shown in the side panel ("X profit in 15 min") but nowhere on the GE screen itself. This puts it where you're actually looking: on the offer you're hovering, so you can gauge how long a flip should take without opening the panel.

## How it works
- `expectedDuration` only lives on the live `Suggestion`, so `SuggestionManager` now caches the most recent expected duration per item name as suggestions arrive (cleared on `reset()`).
- `TooltipController` looks it up by item name and appends `Est. time: <formatted>` using the existing `UIUtilities.formatSuggestionDuration`, bumping the tooltip height by one line.

No backend changes — the data is already on the client.

## Notes / limitations
- Shown only for items suggested in the current session (the only time `expectedDuration` is available); otherwise the tooltip is unchanged.
- It's the expected *total* duration (consistent with the side panel), not a live countdown.
- Happy to gate it behind a config toggle if you'd prefer it opt-in.
- Two natural follow-ups if you're interested: the per-item cache could be **persisted across sessions**, and `Est. time` could be shown for **any item** (not just suggested ones) if `expectedDuration` were attached to the `/prices` response — happy to do either.

## Testing
Built against client 1.12.28 and run locally — `Est. time` shows under `Profit` on the sell-offer tooltip for suggested items.

Two files, ~28 lines: `model/SuggestionManager.java`, `controller/TooltipController.java`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
