### PR TITLE
Price graph: technical indicators + zoom presets

### DIFF
--- a/src/main/java/com/flippingcopilot/ui/graph/ConfigPanel.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/ConfigPanel.java
@@ -49,12 +49,17 @@ public class ConfigPanel extends JPanel {
         // boolean
         addBooleanSetting(settingsPanel, c, "connectPoints", configInstance.isConnectPoints());
         addBooleanSetting(settingsPanel, c, "showSuggestedPriceLines", configInstance.isShowSuggestedPriceLines());
+        addBooleanSetting(settingsPanel, c, "showEma", configInstance.isShowEma());
+        addBooleanSetting(settingsPanel, c, "showBollinger", configInstance.isShowBollinger());
 
         // colours
         addColorSetting(settingsPanel, c, "lowColor", configInstance.getLowColor());
         addColorSetting(settingsPanel, c, "highColor", configInstance.getHighColor());
         addColorSetting(settingsPanel, c, "lowShadeColor", configInstance.getLowShadeColor());
         addColorSetting(settingsPanel, c, "highShadeColor", configInstance.getHighShadeColor());
+        addColorSetting(settingsPanel, c, "emaUpColor", configInstance.getEmaUpColor());
+        addColorSetting(settingsPanel, c, "emaDownColor", configInstance.getEmaDownColor());
+        addColorSetting(settingsPanel, c, "bollingerCloudColor", configInstance.getBollingerCloudColor());
         addColorSetting(settingsPanel, c, "backgroundColor", configInstance.getBackgroundColor());
         addColorSetting(settingsPanel, c, "plotAreaColor", configInstance.getPlotAreaColor());
         addColorSetting(settingsPanel, c, "textColor", configInstance.getTextColor());
@@ -175,12 +180,19 @@ public class ConfigPanel extends JPanel {
             configInstance.setConnectPoints(connectPointsBox.isSelected());
             JCheckBox showSuggestedPriceLinesBox = (JCheckBox) configComponents.get("showSuggestedPriceLines");
             configInstance.setShowSuggestedPriceLines(showSuggestedPriceLinesBox.isSelected());
+            JCheckBox showEmaBox = (JCheckBox) configComponents.get("showEma");
+            configInstance.setShowEma(showEmaBox.isSelected());
+            JCheckBox showBollingerBox = (JCheckBox) configComponents.get("showBollinger");
+            configInstance.setShowBollinger(showBollingerBox.isSelected());
 
             // colours
             configInstance.setLowColor(extractColor("lowColor"));
             configInstance.setHighColor(extractColor("highColor"));
             configInstance.setLowShadeColor(extractColor("lowShadeColor"));
             configInstance.setHighShadeColor(extractColor("highShadeColor"));
+            configInstance.setEmaUpColor(extractColor("emaUpColor"));
+            configInstance.setEmaDownColor(extractColor("emaDownColor"));
+            configInstance.setBollingerCloudColor(extractColor("bollingerCloudColor"));
             configInstance.setBackgroundColor(extractColor("backgroundColor"));
             configInstance.setPlotAreaColor(extractColor("plotAreaColor"));
             configInstance.setTextColor(extractColor("textColor"));

--- a/src/main/java/com/flippingcopilot/ui/graph/DataManager.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/DataManager.java
@@ -29,6 +29,8 @@ public class DataManager {
     public int minEntryTime;
     public int maxCloseTime;
     public Bounds maxBounds = new Bounds();
+    public Indicators indicators1h;
+    public Indicators indicators5m;
 
     public final Data data;
     private final VisualizeFlipResponse fpr;
@@ -46,7 +48,15 @@ public class DataManager {
         this.data = data;
         this.fpr = fpr;
         processDatapoints();
+        computeIndicators();
         calculateStats();
+    }
+
+    private void computeIndicators() {
+        indicators1h = Indicators.compute(data.low1hTimes, data.low1hPrices,
+                data.high1hTimes, data.high1hPrices, 3600);
+        indicators5m = Indicators.compute(data.low5mTimes, data.low5mPrices,
+                data.high5mTimes, data.high5mPrices, 300);
     }
 
     public Datapoint findClosestPoint(Point mousePos, int hoverRadius, Rectangle pa, Bounds bounds) {
@@ -102,6 +112,28 @@ public class DataManager {
         Bounds b = calculateBounds((p) -> p.time > finalXMin && p.time < finalXMax);
         b.xMax = xMax;
         b.xMin = xMin;
+        return b;
+    }
+
+    public Bounds calculateDayBounds() {
+        // Anchor on the most recent real price point ("now"), not maxBounds.xMax (the prediction horizon)
+        // otherwise a 24h window is dominated by future prediction data.
+        int now = Math.max(lastLowTime, lastHighTime);
+        int start = now - 24 * Constants.HOUR_SECONDS;
+        Bounds b = calculateBounds((p) -> p.time > start && p.time <= now);
+        b.xMin = (start / Constants.HOUR_SECONDS) * Constants.HOUR_SECONDS;
+        b.xMax = (now / Constants.HOUR_SECONDS) * Constants.HOUR_SECONDS + Constants.HOUR_SECONDS;
+        return b;
+    }
+
+    public Bounds calculateEightHourBounds() {
+        // Anchor on the most recent real price point ("now"), not maxBounds.xMax (the prediction horizon)
+        // otherwise an 8h window is dominated by future prediction data.
+        int now = Math.max(lastLowTime, lastHighTime);
+        int start = now - 8 * Constants.HOUR_SECONDS;
+        Bounds b = calculateBounds((p) -> p.time > start && p.time <= now);
+        b.xMin = (start / Constants.HOUR_SECONDS) * Constants.HOUR_SECONDS;
+        b.xMax = (now / Constants.HOUR_SECONDS) * Constants.HOUR_SECONDS + Constants.HOUR_SECONDS;
         return b;
     }
 

--- a/src/main/java/com/flippingcopilot/ui/graph/GraphPanel.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/GraphPanel.java
@@ -6,6 +6,7 @@ import com.flippingcopilot.ui.graph.model.*;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
+import java.util.function.Consumer;
 
 public class GraphPanel extends JPanel {
 
@@ -49,6 +50,8 @@ public class GraphPanel extends JPanel {
         zoomHandler.homeViewBounds = dataManager.calculateHomeBounds();
         zoomHandler.weekViewBounds = dataManager.calculateWeekBounds();
         zoomHandler.monthViewBounds = dataManager.calculateMonthBounds();
+        zoomHandler.dayViewBounds = dataManager.calculateDayBounds();
+        zoomHandler.eightHourViewBounds = dataManager.calculateEightHourBounds();
         if (oldItemID != dataManager.data.itemId) {
             bounds = zoomHandler.homeViewBounds.copy();
         }
@@ -104,6 +107,16 @@ public class GraphPanel extends JPanel {
                     repaint();
                     return;
                 }
+                if (zoomHandler.isOverDayButton(mousePosition)) {
+                    zoomHandler.applyDayView(bounds);
+                    repaint();
+                    return;
+                }
+                if (zoomHandler.isOverEightHourButton(mousePosition)) {
+                    zoomHandler.applyEightHourView(bounds);
+                    repaint();
+                    return;
+                }
                 if (zoomHandler.isOverWeekButton(mousePosition)) {
                     zoomHandler.applyWeekView(bounds);
                     repaint();
@@ -112,6 +125,14 @@ public class GraphPanel extends JPanel {
                 if (zoomHandler.isOverMonthButton(mousePosition)) {
                     zoomHandler.applyMonthView(bounds);
                     repaint();
+                    return;
+                }
+                if (zoomHandler.isOverEmaButton(mousePosition)) {
+                    toggleIndicator(c -> c.setShowEma(!c.isShowEma()));
+                    return;
+                }
+                if (zoomHandler.isOverBbButton(mousePosition)) {
+                    toggleIndicator(c -> c.setShowBollinger(!c.isShowBollinger()));
                     return;
                 }
 
@@ -160,6 +181,13 @@ public class GraphPanel extends JPanel {
 
         addMouseMotionListener(mouseAdapter);
         addMouseListener(mouseAdapter);
+    }
+
+    private void toggleIndicator(Consumer<Config> toggle) {
+        Config config = configManager.getConfig();
+        toggle.accept(config);
+        configManager.setConfig(config);
+        repaint();
     }
 
 
@@ -213,6 +241,14 @@ public class GraphPanel extends JPanel {
         renderer.drawXAxisLabels(g2d, config, volumePa, bounds, xAxis);
 
 
+        Indicators indicators = pickIndicators();
+        if (config.isShowBollinger()) {
+            renderer.drawIndicatorBand(g2d, pricePa, bounds, indicators.bollinger, config.getBollingerCloudColor());
+        }
+        if (config.isShowEma()) {
+            renderer.drawEmaCloud(g2d, pricePa, bounds, indicators.emaFast, indicators.emaSlow, config.getEmaUpColor(), config.getEmaDownColor());
+        }
+
         int pointSize = dynamicPointSize(Config.BASE_POINT_SIZE, bounds);
         renderer.drawPoints(g2d, pricePa, bounds, dataManager.lowDatapoints, config.lowColor, pointSize);
         renderer.drawPoints(g2d, pricePa, bounds, dataManager.highDatapoints, config.highColor, pointSize);
@@ -232,7 +268,7 @@ public class GraphPanel extends JPanel {
             renderer.drawPredictionIQR(g2d, config, pricePa, bounds, data.predictionTimes, data.predictionLowIQRLower, data.predictionLowIQRUpper, true);
             renderer.drawPredictionIQR(g2d, config, pricePa, bounds, data.predictionTimes, data.predictionHighIQRLower, data.predictionHighIQRUpper, false);
         }
-        zoomHandler.drawButtons(g2d, pricePa, mousePosition);
+        zoomHandler.drawButtons(g2d, pricePa, mousePosition, config);
         zoomHandler.drawSelectionRectangle(g2d, pricePa);
 
         renderer.drawVolumeBars(g2d, config, volumePa, bounds, dataManager.volumes, hoveredPoint);
@@ -278,6 +314,12 @@ public class GraphPanel extends JPanel {
                 ? Math.max(pricePa.y + metrics.getAscent(), y - (Config.LABEL_PADDING / 2))
                 : Math.min(pricePa.y + pricePa.height - Config.LABEL_PADDING, y + metrics.getAscent() + (Config.LABEL_PADDING / 2));
         g2d.drawString(label, labelX, labelY);
+    }
+
+    private Indicators pickIndicators() {
+        boolean use5m = bounds.xDelta() <= 7 * Constants.DAY_SECONDS
+                && dataManager.indicators5m.covers(bounds.xMin);
+        return use5m ? dataManager.indicators5m : dataManager.indicators1h;
     }
 
     private int dynamicPointSize(int baseSize, Bounds bounds) {

--- a/src/main/java/com/flippingcopilot/ui/graph/IndicatorCalculator.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/IndicatorCalculator.java
@@ -1,0 +1,68 @@
+package com.flippingcopilot.ui.graph;
+
+import com.flippingcopilot.ui.graph.model.IndicatorBand;
+import com.flippingcopilot.ui.graph.model.IndicatorSeries;
+
+public class IndicatorCalculator {
+
+    public static final double BOLLINGER_STD_DEVS = 2.0;
+
+    private IndicatorCalculator() {
+    }
+
+    public static IndicatorSeries ema(int[] times, int[] prices, int period) {
+        if (times == null || prices == null || times.length < period) {
+            return IndicatorSeries.EMPTY;
+        }
+        int n = times.length;
+        int[] outTimes = new int[n - period + 1];
+        double[] outValues = new double[n - period + 1];
+
+        double sum = 0;
+        for (int i = 0; i < period; i++) {
+            sum += prices[i];
+        }
+        double ema = sum / period;
+        outTimes[0] = times[period - 1];
+        outValues[0] = ema;
+
+        double k = 2.0 / (period + 1);
+        for (int i = period; i < n; i++) {
+            ema = prices[i] * k + ema * (1 - k);
+            outTimes[i - period + 1] = times[i];
+            outValues[i - period + 1] = ema;
+        }
+        return new IndicatorSeries(outTimes, outValues);
+    }
+
+    public static IndicatorBand bollinger(int[] times, int[] prices, int period, double numStdDevs) {
+        if (times == null || prices == null || times.length < period) {
+            return IndicatorBand.EMPTY;
+        }
+        int n = times.length;
+        int outN = n - period + 1;
+        int[] outTimes = new int[outN];
+        double[] upper = new double[outN];
+        double[] lower = new double[outN];
+        double[] middle = new double[outN];
+
+        for (int i = 0; i < outN; i++) {
+            double sum = 0;
+            for (int j = i; j < i + period; j++) {
+                sum += prices[j];
+            }
+            double mean = sum / period;
+            double sqSum = 0;
+            for (int j = i; j < i + period; j++) {
+                double d = prices[j] - mean;
+                sqSum += d * d;
+            }
+            double sigma = Math.sqrt(sqSum / period);
+            outTimes[i] = times[i + period - 1];
+            upper[i] = mean + numStdDevs * sigma;
+            lower[i] = mean - numStdDevs * sigma;
+            middle[i] = mean;
+        }
+        return new IndicatorBand(outTimes, upper, lower, middle);
+    }
+}

--- a/src/main/java/com/flippingcopilot/ui/graph/Indicators.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/Indicators.java
@@ -1,0 +1,78 @@
+package com.flippingcopilot.ui.graph;
+
+import com.flippingcopilot.ui.graph.model.IndicatorBand;
+import com.flippingcopilot.ui.graph.model.IndicatorSeries;
+
+import static com.flippingcopilot.ui.graph.IndicatorCalculator.BOLLINGER_STD_DEVS;
+
+public class Indicators {
+
+    private static final int EMA_FAST_SPAN = 43200; // 12h
+    private static final int EMA_SLOW_SPAN = 86400; // 24h
+    private static final int BOLLINGER_SPAN = 86400; // 24h
+
+    public final IndicatorSeries emaFast;
+    public final IndicatorSeries emaSlow;
+    public final IndicatorBand bollinger;
+    private final int firstTime;
+
+    private Indicators(IndicatorSeries emaFast, IndicatorSeries emaSlow,
+                       IndicatorBand bollinger,
+                       int firstTime) {
+        this.emaFast = emaFast;
+        this.emaSlow = emaSlow;
+        this.bollinger = bollinger;
+        this.firstTime = firstTime;
+    }
+
+    public static Indicators compute(int[] lowTimes, int[] lowPrices,
+                                     int[] highTimes, int[] highPrices,
+                                     int resolutionSeconds) {
+        int firstTime = Integer.MAX_VALUE;
+        if (lowTimes != null && lowTimes.length > 0) {
+            firstTime = Math.min(firstTime, lowTimes[0]);
+        }
+        if (highTimes != null && highTimes.length > 0) {
+            firstTime = Math.min(firstTime, highTimes[0]);
+        }
+
+        int fastPeriod = Math.max(1, Math.round((float) EMA_FAST_SPAN / resolutionSeconds));
+        int slowPeriod = Math.max(1, Math.round((float) EMA_SLOW_SPAN / resolutionSeconds));
+        int bollingerPeriod = Math.max(1, Math.round((float) BOLLINGER_SPAN / resolutionSeconds));
+
+        int[] midTimes = null;
+        int[] midPrices = null;
+        if (lowTimes != null && highTimes != null) {
+            midTimes = new int[Math.min(lowTimes.length, highTimes.length)];
+            midPrices = new int[midTimes.length];
+            int count = 0;
+            int i = 0;
+            int j = 0;
+            while (i < lowTimes.length && j < highTimes.length) {
+                if (lowTimes[i] == highTimes[j]) {
+                    midTimes[count] = lowTimes[i];
+                    midPrices[count] = (int) (((long) lowPrices[i] + highPrices[j]) / 2);
+                    count++;
+                    i++;
+                    j++;
+                } else if (lowTimes[i] < highTimes[j]) {
+                    i++;
+                } else {
+                    j++;
+                }
+            }
+            midTimes = java.util.Arrays.copyOf(midTimes, count);
+            midPrices = java.util.Arrays.copyOf(midPrices, count);
+        }
+
+        return new Indicators(
+                IndicatorCalculator.ema(midTimes, midPrices, fastPeriod),
+                IndicatorCalculator.ema(midTimes, midPrices, slowPeriod),
+                IndicatorCalculator.bollinger(midTimes, midPrices, bollingerPeriod, BOLLINGER_STD_DEVS),
+                firstTime);
+    }
+
+    public boolean covers(int time) {
+        return firstTime <= time;
+    }
+}

--- a/src/main/java/com/flippingcopilot/ui/graph/RenderV2.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/RenderV2.java
@@ -407,4 +407,92 @@ public class RenderV2 {
 
         g2d.setClip(originalClip);
     }
+
+    public void drawEmaCloud(Graphics2D g2d, Rectangle pa, Bounds bounds, IndicatorSeries fast, IndicatorSeries slow, Color upColor, Color downColor) {
+        if (fast == null || slow == null || fast.times.length == 0 || slow.times.length == 0) return;
+
+        // align fast and slow by timestamp (two-pointer walk; slow.times is a
+        // later-starting subset of fast.times with matching timestamps where they overlap)
+        int n = Math.min(fast.times.length, slow.times.length);
+        int[] alignedTimes = new int[n];
+        double[] fastVals = new double[n];
+        double[] slowVals = new double[n];
+        int count = 0;
+        int i = 0;
+        int j = 0;
+        while (i < fast.times.length && j < slow.times.length) {
+            if (fast.times[i] == slow.times[j]) {
+                alignedTimes[count] = fast.times[i];
+                fastVals[count] = fast.values[i];
+                slowVals[count] = slow.values[j];
+                count++;
+                i++;
+                j++;
+            } else if (fast.times[i] < slow.times[j]) {
+                i++;
+            } else {
+                j++;
+            }
+        }
+
+        if (count < 2) return;
+
+        java.awt.Shape originalClip = g2d.getClip();
+        g2d.setClip(pa.x, pa.y, pa.width, pa.height);
+
+        for (int k = 0; k < count - 1; k++) {
+            int x1 = bounds.toX(pa, alignedTimes[k]);
+            int x2 = bounds.toX(pa, alignedTimes[k + 1]);
+            int fastY1 = bounds.toY(pa, Math.round(fastVals[k]));
+            int slowY1 = bounds.toY(pa, Math.round(slowVals[k]));
+            int fastY2 = bounds.toY(pa, Math.round(fastVals[k + 1]));
+            int slowY2 = bounds.toY(pa, Math.round(slowVals[k + 1]));
+
+            Path2D.Float quad = new Path2D.Float();
+            quad.moveTo(x1, fastY1);
+            quad.lineTo(x1, slowY1);
+            quad.lineTo(x2, slowY2);
+            quad.lineTo(x2, fastY2);
+            quad.closePath();
+
+            g2d.setColor(fastVals[k] >= slowVals[k] ? upColor : downColor);
+            g2d.fill(quad);
+        }
+
+        g2d.setClip(originalClip);
+    }
+
+    public void drawIndicatorBand(Graphics2D g2d, Rectangle pa, Bounds bounds, IndicatorBand band, Color shadeColor) {
+        if (band == null || band.times.length < 2) return;
+
+        java.awt.Shape originalClip = g2d.getClip();
+        g2d.setClip(pa.x, pa.y, pa.width, pa.height);
+
+        // shaded fill: lower edge forward, upper edge backward
+        Path2D.Float fill = new Path2D.Float();
+        fill.moveTo(bounds.toX(pa, band.times[0]), bounds.toY(pa, Math.round(band.lower[0])));
+        for (int i = 1; i < band.times.length; i++) {
+            fill.lineTo(bounds.toX(pa, band.times[i]), bounds.toY(pa, Math.round(band.lower[i])));
+        }
+        for (int i = band.times.length - 1; i >= 0; i--) {
+            fill.lineTo(bounds.toX(pa, band.times[i]), bounds.toY(pa, Math.round(band.upper[i])));
+        }
+        fill.closePath();
+        g2d.setColor(shadeColor);
+        g2d.fill(fill);
+
+        // thin upper/middle/lower lines, opaque version of the shade color
+        Color lineColor = new Color(shadeColor.getRed(), shadeColor.getGreen(), shadeColor.getBlue());
+        g2d.setColor(lineColor);
+        g2d.setStroke(Config.THIN_STROKE);
+        for (double[] edge : new double[][]{band.lower, band.upper, band.middle}) {
+            Path2D.Float path = new Path2D.Float();
+            path.moveTo(bounds.toX(pa, band.times[0]), bounds.toY(pa, Math.round(edge[0])));
+            for (int i = 1; i < band.times.length; i++) {
+                path.lineTo(bounds.toX(pa, band.times[i]), bounds.toY(pa, Math.round(edge[i])));
+            }
+            g2d.draw(path);
+        }
+        g2d.setClip(originalClip);
+    }
 }

--- a/src/main/java/com/flippingcopilot/ui/graph/ZoomHandler.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/ZoomHandler.java
@@ -28,11 +28,17 @@ public class ZoomHandler {
     private final Rectangle zoomOutButtonRect = new Rectangle();
     private final Rectangle weekButtonRect = new Rectangle();
     private final Rectangle monthButtonRect = new Rectangle();
+    private final Rectangle dayButtonRect = new Rectangle();
+    private final Rectangle eightHourButtonRect = new Rectangle();
+    private final Rectangle emaButtonRect = new Rectangle();
+    private final Rectangle bbButtonRect = new Rectangle();
 
     public Bounds maxViewBounds;
     public Bounds homeViewBounds;
     public Bounds weekViewBounds;
     public Bounds monthViewBounds;
+    public Bounds dayViewBounds;
+    public Bounds eightHourViewBounds;
 
     public void startSelection(Point point) {
         selectionStart = new Point(point);
@@ -106,6 +112,14 @@ public class ZoomHandler {
         copyBounds(bounds, monthViewBounds);
     }
 
+    public void applyDayView(Bounds bounds) {
+        copyBounds(bounds, dayViewBounds);
+    }
+
+    public void applyEightHourView(Bounds bounds) {
+        copyBounds(bounds, eightHourViewBounds);
+    }
+
     private void copyBounds(Bounds target, Bounds source) {
         target.xMin = source.xMin;
         target.xMax = source.xMax;
@@ -137,7 +151,7 @@ public class ZoomHandler {
         g2d.drawRect(x1, y1, x2-x1, y2 - y1);
     }
 
-    public void drawButtons(Graphics2D g2d, Rectangle pa, Point p) {
+    public void drawButtons(Graphics2D g2d, Rectangle pa, Point p, Config config) {
         int size = Config.GRAPH_BUTTON_SIZE;
         int x = pa.x + pa.width - size - Config.GRAPH_BUTTON_MARGIN;
         int y = pa.y + Config.GRAPH_BUTTON_MARGIN;
@@ -164,8 +178,21 @@ public class ZoomHandler {
         // Draw - symbol
         drawPlusMinusIcon(g2d, zoomOutButtonRect, false);
 
-        // Width for text buttons (Week and Month)
+        // Width for text buttons (8h, Day, Week, Month)
         int textButtonWidth = size * 2;
+
+        // Text buttons ordered by span, shortest (8h) rightmost: left-to-right Month, Week, Day, 8h.
+        // Draw 8h button (rightmost of the text buttons)
+        x -= textButtonWidth + Config.GRAPH_BUTTON_MARGIN;
+        drawButtonBackground(g2d, eightHourButtonRect, x, y, textButtonWidth, isOverEightHourButton(p));
+        // Draw 8h text
+        drawCenteredText(g2d, eightHourButtonRect, "8h");
+
+        // Draw Day button
+        x -= textButtonWidth + Config.GRAPH_BUTTON_MARGIN;
+        drawButtonBackground(g2d, dayButtonRect, x, y, textButtonWidth, isOverDayButton(p));
+        // Draw Day text
+        drawCenteredText(g2d, dayButtonRect, "Day");
 
         // Draw Week button (wider than the others)
         x -= textButtonWidth + Config.GRAPH_BUTTON_MARGIN;
@@ -178,12 +205,34 @@ public class ZoomHandler {
         drawButtonBackground(g2d, monthButtonRect, x, y, textButtonWidth, isOverMonthButton(p));
         // Draw Month text
         drawCenteredText(g2d, monthButtonRect, "Month");
+
+        // Second row: indicator toggle buttons, right-aligned beneath the zoom row.
+        // Drawn right-to-left so they read left-to-right as EMA, BB.
+        int y2 = pa.y + Config.GRAPH_BUTTON_MARGIN + size + Config.GRAPH_BUTTON_MARGIN;
+        int x2 = pa.x + pa.width - textButtonWidth - Config.GRAPH_BUTTON_MARGIN;
+        drawToggleButtonBackground(g2d, bbButtonRect, x2, y2, textButtonWidth, isOverBbButton(p), config.isShowBollinger());
+        drawCenteredText(g2d, bbButtonRect, "BB");
+
+        x2 -= textButtonWidth + Config.GRAPH_BUTTON_MARGIN;
+        drawToggleButtonBackground(g2d, emaButtonRect, x2, y2, textButtonWidth, isOverEmaButton(p), config.isShowEma());
+        drawCenteredText(g2d, emaButtonRect, "EMA");
     }
 
     private void drawButtonBackground(Graphics2D g2d, Rectangle rect, int x, int y, int width, boolean hovered) {
         rect.setBounds(x, y, width, Config.GRAPH_BUTTON_SIZE);
         g2d.setColor(hovered ? Config.GRAPH_BUTTON_HOVER_COLOR : Config.GRAPH_BUTTON_COLOR);
         g2d.fill(new RoundRectangle2D.Float(x, y, width, Config.GRAPH_BUTTON_SIZE, 6, 6));
+    }
+
+    private void drawToggleButtonBackground(Graphics2D g2d, Rectangle rect, int x, int y, int width, boolean hovered, boolean active) {
+        rect.setBounds(x, y, width, Config.GRAPH_BUTTON_SIZE);
+        g2d.setColor(active || hovered ? Config.GRAPH_BUTTON_HOVER_COLOR : Config.GRAPH_BUTTON_COLOR);
+        g2d.fill(new RoundRectangle2D.Float(x, y, width, Config.GRAPH_BUTTON_SIZE, 6, 6));
+        if (active) {
+            g2d.setColor(Color.WHITE);
+            g2d.setStroke(new BasicStroke(1f));
+            g2d.draw(new RoundRectangle2D.Float(x, y, width, Config.GRAPH_BUTTON_SIZE, 6, 6));
+        }
     }
 
     private void drawHomeIcon(Graphics2D g2d, Rectangle rect) {
@@ -281,5 +330,21 @@ public class ZoomHandler {
 
     public boolean isOverMonthButton(Point point) {
         return isOver(monthButtonRect, point);
+    }
+
+    public boolean isOverDayButton(Point point) {
+        return isOver(dayButtonRect, point);
+    }
+
+    public boolean isOverEightHourButton(Point point) {
+        return isOver(eightHourButtonRect, point);
+    }
+
+    public boolean isOverEmaButton(Point point) {
+        return isOver(emaButtonRect, point);
+    }
+
+    public boolean isOverBbButton(Point point) {
+        return isOver(bbButtonRect, point);
     }
 }

--- a/src/main/java/com/flippingcopilot/ui/graph/model/Config.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/model/Config.java
@@ -43,10 +43,15 @@ public class Config {
     // configurable properties
     public boolean connectPoints = true;
     public boolean showSuggestedPriceLines = true;
+    public boolean showEma = false;
+    public boolean showBollinger = false;
     public Color lowColor = new Color(0, 153, 255);
     public Color highColor = new Color(255, 102, 0);
     public Color lowShadeColor = new Color(0, 153, 255, 60);
     public Color highShadeColor = new Color(255, 102, 0, 60);
+    public Color emaUpColor = new Color(34, 197, 94, 120);    // Tailwind green-500
+    public Color emaDownColor = new Color(239, 68, 68, 120);  // Tailwind red-500
+    public Color bollingerCloudColor = new Color(148, 163, 184, 45); // Tailwind slate-400
 
     public Color backgroundColor = ColorScheme.DARKER_GRAY_COLOR.brighter();
     public Color plotAreaColor = new Color(51, 51, 51);

--- a/src/main/java/com/flippingcopilot/ui/graph/model/IndicatorBand.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/model/IndicatorBand.java
@@ -1,0 +1,18 @@
+package com.flippingcopilot.ui.graph.model;
+
+public class IndicatorBand {
+
+    public static final IndicatorBand EMPTY = new IndicatorBand(new int[0], new double[0], new double[0], new double[0]);
+
+    public final int[] times;
+    public final double[] upper;
+    public final double[] lower;
+    public final double[] middle;
+
+    public IndicatorBand(int[] times, double[] upper, double[] lower, double[] middle) {
+        this.times = times;
+        this.upper = upper;
+        this.lower = lower;
+        this.middle = middle;
+    }
+}

--- a/src/main/java/com/flippingcopilot/ui/graph/model/IndicatorSeries.java
+++ b/src/main/java/com/flippingcopilot/ui/graph/model/IndicatorSeries.java
@@ -1,0 +1,14 @@
+package com.flippingcopilot.ui.graph.model;
+
+public class IndicatorSeries {
+
+    public static final IndicatorSeries EMPTY = new IndicatorSeries(new int[0], new double[0]);
+
+    public final int[] times;
+    public final double[] values;
+
+    public IndicatorSeries(int[] times, double[] values) {
+        this.times = times;
+        this.values = values;
+    }
+}

--- a/src/test/java/com/flippingcopilot/ui/graph/IndicatorCalculatorTest.java
+++ b/src/test/java/com/flippingcopilot/ui/graph/IndicatorCalculatorTest.java
@@ -1,0 +1,59 @@
+package com.flippingcopilot.ui.graph;
+
+import com.flippingcopilot.ui.graph.model.IndicatorBand;
+import com.flippingcopilot.ui.graph.model.IndicatorSeries;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class IndicatorCalculatorTest {
+
+    @Test
+    public void emaSeedsWithSmaThenRecurses() {
+        int[] times = {100, 200, 300, 400};
+        int[] prices = {10, 20, 30, 40};
+
+        // period 3: seed = SMA(10,20,30) = 20 at t=300; k = 2/(3+1) = 0.5
+        // next = 40*0.5 + 20*0.5 = 30 at t=400
+        IndicatorSeries s = IndicatorCalculator.ema(times, prices, 3);
+
+        assertArrayEquals(new int[]{300, 400}, s.times);
+        assertArrayEquals(new double[]{20.0, 30.0}, s.values, 1e-9);
+    }
+
+    @Test
+    public void emaTooShortInputReturnsEmpty() {
+        IndicatorSeries s = IndicatorCalculator.ema(new int[]{100, 200}, new int[]{10, 20}, 3);
+        assertEquals(0, s.times.length);
+        assertEquals(0, s.values.length);
+    }
+
+    @Test
+    public void emaNullInputReturnsEmpty() {
+        IndicatorSeries s = IndicatorCalculator.ema(null, null, 3);
+        assertEquals(0, s.times.length);
+    }
+
+    @Test
+    public void bollingerComputesMeanPlusMinusSigma() {
+        int[] times = {100, 200, 300, 400};
+        int[] prices = {10, 20, 30, 40};
+
+        // period 3, 2σ, population σ:
+        // window [10,20,30]: mean 20, σ = sqrt(200/3); window [20,30,40]: mean 30, same σ
+        double twoSigma = 2.0 * Math.sqrt(200.0 / 3.0);
+        IndicatorBand b = IndicatorCalculator.bollinger(times, prices, 3, 2.0);
+
+        assertArrayEquals(new int[]{300, 400}, b.times);
+        assertArrayEquals(new double[]{20.0 + twoSigma, 30.0 + twoSigma}, b.upper, 1e-9);
+        assertArrayEquals(new double[]{20.0 - twoSigma, 30.0 - twoSigma}, b.lower, 1e-9);
+        assertArrayEquals(new double[]{20.0, 30.0}, b.middle, 1e-9);
+    }
+
+    @Test
+    public void bollingerTooShortOrNullReturnsEmpty() {
+        assertEquals(0, IndicatorCalculator.bollinger(new int[]{100}, new int[]{10}, 3, 2.0).times.length);
+        assertEquals(0, IndicatorCalculator.bollinger(null, null, 3, 2.0).times.length);
+    }
+}

--- a/src/test/java/com/flippingcopilot/ui/graph/IndicatorsTest.java
+++ b/src/test/java/com/flippingcopilot/ui/graph/IndicatorsTest.java
@@ -1,0 +1,133 @@
+package com.flippingcopilot.ui.graph;
+
+import com.flippingcopilot.ui.graph.model.Data;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class IndicatorsTest {
+
+    private static int[] range(int start, int step, int count) {
+        int[] out = new int[count];
+        for (int i = 0; i < count; i++) {
+            out[i] = start + i * step;
+        }
+        return out;
+    }
+
+    private static int[] constant(int value, int count) {
+        int[] out = new int[count];
+        java.util.Arrays.fill(out, value);
+        return out;
+    }
+
+    @Test
+    public void computeProducesAllSeriesPerSide() {
+        int n = 30; // > slow EMA period (24) and Bollinger period (24) at 3600s resolution
+        int[] times = range(3600, 3600, n);
+        Indicators ind = Indicators.compute(
+                times, constant(100, n),
+                times, constant(110, n), 3600);
+
+        // warm-up: outputs start at period-1
+        assertEquals(n - 12 + 1, ind.emaFast.times.length);
+        assertEquals(n - 24 + 1, ind.emaSlow.times.length);
+        assertEquals(n - 24 + 1, ind.bollinger.times.length);
+
+        // mid-price of low=100, high=110 is 105; constant prices -> EMA flat at the mid price
+        assertEquals(105.0, ind.emaFast.values[0], 1e-9);
+        // constant mid-price -> zero std dev, so upper/middle/lower all collapse to 105
+        assertEquals(105.0, ind.bollinger.middle[0], 1e-9);
+        assertEquals(105.0, ind.bollinger.upper[0], 1e-9);
+        assertEquals(105.0, ind.bollinger.lower[0], 1e-9);
+    }
+
+    @Test
+    public void midPriceDoesNotOverflowForHighValueItems() {
+        // low+high exceeds Integer.MAX_VALUE (e.g. billion-gp items like Twisted bow);
+        // the mid must be their true average, not a negative int overflow.
+        int n = 30;
+        int[] times = range(3600, 3600, n);
+        Indicators ind = Indicators.compute(
+                times, constant(2_000_000_000, n),
+                times, constant(2_100_000_000, n), 3600);
+
+        assertEquals(2_050_000_000.0, ind.emaFast.values[0], 1.0);
+    }
+
+    @Test
+    public void computeWithNullArraysProducesEmptySeries() {
+        Indicators ind = Indicators.compute(null, null, null, null, 3600);
+        assertNotNull(ind);
+        assertEquals(0, ind.emaFast.times.length);
+        assertEquals(0, ind.bollinger.times.length);
+        assertFalse(ind.covers(0));
+    }
+
+    @Test
+    public void coversReflectsEarliestPriceTime() {
+        int n = 30;
+        int[] times = range(1000, 3600, n);
+        Indicators ind = Indicators.compute(
+                times, constant(100, n),
+                times, constant(110, n), 3600);
+        assertTrue(ind.covers(1000));
+        assertTrue(ind.covers(50_000));
+        assertFalse(ind.covers(999));
+    }
+
+    @Test
+    public void emaPeriodDerivedFromResolution() {
+        // 30 hourly bins; slow EMA span 24h at 3600s/bin -> period 24 -> output length 30-24+1 = 7
+        int n = 30;
+        int[] times = range(3600, 3600, n);
+        Indicators ind = Indicators.compute(times, constant(100, n), times, constant(110, n), 3600);
+        assertEquals(7, ind.emaSlow.times.length);   // period 24
+        assertEquals(19, ind.emaFast.times.length);  // period 12 (span 43200/3600)
+        // mid-price of low=100, high=110 is 105
+        assertEquals(105.0, ind.emaFast.values[0], 1e-9);
+    }
+
+    @Test
+    public void fiveMinuteResolutionUsesLargerPeriod() {
+        int n = 300;
+        int[] times = range(300, 300, n);
+        // slow span 86400 / 300 = 288 -> output length 300-288+1 = 13
+        Indicators ind = Indicators.compute(times, constant(100, n), times, constant(110, n), 300);
+        assertEquals(13, ind.emaSlow.times.length);
+    }
+
+    @Test
+    public void dataManagerComputesBothResolutions() {
+        int n = 30;
+        // 5m bins need enough history to fill the 24h Bollinger/EMA span (period 288 at 300s resolution)
+        int n5m = 300;
+        Data data = new Data();
+        data.low1hTimes = range(3600, 3600, n);
+        data.low1hPrices = constant(100, n);
+        data.high1hTimes = range(3600, 3600, n);
+        data.high1hPrices = constant(110, n);
+        data.low5mTimes = range(300, 300, n5m);
+        data.low5mPrices = constant(100, n5m);
+        data.high5mTimes = range(300, 300, n5m);
+        data.high5mPrices = constant(110, n5m);
+        data.volume1hTimes = range(3600, 3600, n);
+        data.volume1hLows = constant(5, n);
+        data.volume1hHighs = constant(7, n);
+        data.volume5mTimes = range(300, 300, n5m);
+        data.volume5mLows = constant(2, n5m);
+        data.volume5mHighs = constant(3, n5m);
+        // lowLatestTimes left null: processDatapoints() returns early, indicators must still compute
+
+        DataManager dm = new DataManager(data, null);
+
+        assertNotNull(dm.indicators1h);
+        assertNotNull(dm.indicators5m);
+        assertTrue(dm.indicators1h.emaFast.times.length > 0);
+        assertTrue(dm.indicators1h.emaSlow.times.length > 0);
+        assertTrue(dm.indicators5m.bollinger.times.length > 0);
+    }
+}

--- a/src/test/java/com/flippingcopilot/ui/graph/model/ConfigSerializationTest.java
+++ b/src/test/java/com/flippingcopilot/ui/graph/model/ConfigSerializationTest.java
@@ -1,0 +1,51 @@
+package com.flippingcopilot.ui.graph.model;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import java.awt.Color;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigSerializationTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    public void indicatorTogglesDefaultToOff() {
+        Config c = new Config();
+        assertFalse(c.isShowEma());
+        assertFalse(c.isShowBollinger());
+    }
+
+    @Test
+    public void indicatorTogglesSurviveJsonRoundTrip() {
+        Config c = new Config();
+        c.setShowEma(true);
+
+        Config loaded = gson.fromJson(gson.toJson(c), Config.class);
+
+        assertTrue(loaded.isShowEma());
+        assertFalse(loaded.isShowBollinger());
+    }
+
+    @Test
+    public void legacyConfigJsonWithoutToggleFieldsLoadsWithTogglesOff() {
+        // simulates a price_graph_config.json written before this feature existed
+        Config loaded = gson.fromJson("{\"connectPoints\":true}", Config.class);
+        assertFalse(loaded.isShowEma());
+        assertFalse(loaded.isShowBollinger());
+    }
+
+    @Test
+    public void indicatorColorsRoundTripAndDefault() {
+        Config c = new Config();
+        assertEquals(new Color(34, 197, 94, 120), c.getEmaUpColor());
+        assertEquals(new Color(239, 68, 68, 120), c.getEmaDownColor());
+        assertEquals(new Color(148, 163, 184, 45), c.getBollingerCloudColor());
+        Config loaded = gson.fromJson("{\"connectPoints\":true}", Config.class);
+        assertEquals(new Color(34, 197, 94, 120), loaded.getEmaUpColor());
+    }
+}


### PR DESCRIPTION
Adds toggleable technical-indicator overlays to the item price graph (an EMA trend cloud and a Bollinger cloud) plus Day (24h) and 8h range presets. The indicators make it easy to see at a glance whether an item is trending, crashing, or ranging, so you can time entries and avoid buying into a falling price.

<img width="2592" height="1158" alt="CleanShot 2026-07-18 at 00 45 20" src="https://github.com/user-attachments/assets/6742cc6a-1141-4a9f-a54d-113eaaf04758" />
<img width="2624" height="1154" alt="CleanShot 2026-07-18 at 00 43 01" src="https://github.com/user-attachments/assets/e00ed7f7-d536-4e9d-9ce0-44d1d59676b8" />


# What's new

**Indicators** toggled with the `EMA` / `BB` buttons on the graph (off by default):

- **EMA trend cloud**: the filled area between a fast (12h) and slow (24h) exponential moving average of the mid-price. It's **green when the fast EMA is above the slow (uptrend) and red when below (downtrend)**, and the band's thickness reflects momentum, pinching to nothing at each crossover where the trend flips. This replaces the usual two-line EMA display with a single, direction-colored signal you don't have to interpret.
- **Bollinger cloud**: a single band on the mid-price with **upper / middle / lower** lines (middle = 24h moving average, upper/lower = ±2 standard deviations). Its width shows recent volatility; price near the lower edge is relatively cheap, near the upper edge relatively expensive.

Zoom presets:
- New Day (last 24h) and 8h buttons alongside the existing Week/Month, anchored on the most recent price.

Behaviour & polish:
- Indicator windows are time-based (a fixed real-time span), so they read consistently at every zoom level. The graph automatically computes on 5-minute data when zoomed in and hourly data when zoomed out.
- Indicator colours are editable in the graph settings panel (defaults use a Tailwind palette: green-500 / red-500 / slate-400). Toggle state persists across sessions.

## How to read it

- Green cloud + price at the lower Bollinger edge → good buy setup.
- Red cloud + price falling → downtrend, don't buy into it.
- Thin Bollinger cloud = calm/stable (reliable flips); fat cloud = volatile (more upside and more risk).